### PR TITLE
Add a pi (pi-coding-agent) integration

### DIFF
--- a/.pi/extensions/token-goat.ts
+++ b/.pi/extensions/token-goat.ts
@@ -1,0 +1,156 @@
+// token-goat bridge extension for pi (pi-coding-agent)
+// Bridges pi's extension events to token-goat's subprocess hook protocol.
+// https://github.com/DFKHelper/token-goat
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawnSync } from "node:child_process";
+
+// pi built-in tool names -> token-goat internal tool names
+const TOOL_TO_TG: Record<string, string> = {
+  read: "Read",
+  bash: "Bash",
+  edit: "Edit",
+  write: "Write",
+  grep: "Grep",
+  find: "Glob",
+};
+
+// pi tool args (camelCase/short) -> token-goat snake_case tool_input keys
+const ARGS_TO_TG: Record<string, Record<string, string>> = {
+  read: { path: "file_path", offset: "offset", limit: "limit" },
+  bash: { command: "command", timeout: "timeout" },
+  edit: { path: "file_path" },
+  write: { path: "file_path" },
+  grep: { pattern: "pattern", path: "path" },
+  find: { pattern: "pattern", path: "path" },
+};
+
+// Post-call hook event per token-goat tool name
+const POST_HOOK: Record<string, string> = {
+  Read: "post-read",
+  Grep: "post-read",
+  Glob: "post-read",
+  Bash: "post-bash",
+  WebFetch: "post-fetch",
+  Edit: "post-edit",
+  Write: "post-edit",
+};
+
+// Tools that have a pre-hook (read/search/fetch types only).
+// Edit/Write tools have no pre-hook in token-goat; skip before-dispatch for them.
+const PRE_HOOK_TOOLS = new Set(["Read", "Grep", "Glob", "Bash", "WebFetch"]);
+
+function callHook(event: string, payload: Record<string, unknown>): Record<string, unknown> | null {
+  try {
+    const r = spawnSync("token-goat", ["hook", event], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    if (r.error) return null;
+    const out = r.stdout?.trim();
+    if (!out) return null;
+    return JSON.parse(out) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function reverseArgMap(tool: string): Record<string, string> {
+  const fwd = ARGS_TO_TG[tool] ?? {};
+  return Object.fromEntries(Object.entries(fwd).map(([piKey, tgKey]) => [tgKey, piKey]));
+}
+
+function toToolInput(tool: string, input: Record<string, unknown>): Record<string, unknown> {
+  const argMap = ARGS_TO_TG[tool] ?? {};
+  const out: Record<string, unknown> = {};
+  for (const [piKey, tgKey] of Object.entries(argMap)) {
+    if (input[piKey] !== undefined) out[tgKey] = input[piKey];
+  }
+  return out;
+}
+
+export default function (pi: ExtensionAPI) {
+  // Stable per-session id derived from pi's session file (filesystem-safe), or
+  // a process-scoped fallback for ephemeral sessions. Recomputed on every
+  // session_start (new / resume / fork all re-fire it).
+  let sessionId = `pi-${process.pid}`;
+  let cwd = process.cwd();
+  // Manifest captured at session_before_compact, injected after compaction.
+  let pendingManifest: string | undefined;
+
+  pi.on("session_start", (_event, ctx) => {
+    cwd = ctx.cwd ?? process.cwd();
+    const file = ctx.sessionManager?.getSessionFile?.();
+    sessionId = file ? `pi-${file.replace(/[^A-Za-z0-9._-]/g, "_")}` : `pi-${process.pid}`;
+    callHook("session-start", { session_id: sessionId, cwd });
+  });
+
+  pi.on("tool_call", async (event, _ctx) => {
+    const tg = TOOL_TO_TG[event.toolName];
+    if (!tg || !PRE_HOOK_TOOLS.has(tg)) return;
+
+    const input = event.input as Record<string, unknown>;
+    const hookEvent = tg === "WebFetch" ? "pre-fetch" : "pre-read";
+    const resp = callHook(hookEvent, {
+      session_id: sessionId,
+      tool_name: tg,
+      tool_input: toToolInput(event.toolName, input),
+      cwd,
+    });
+    if (!resp) return;
+
+    const hso = resp["hookSpecificOutput"] as Record<string, unknown> | undefined;
+    if (!hso) return;
+
+    // Deny: block the tool call with a reason (e.g. confirmed re-read).
+    if (hso["permissionDecision"] === "deny") {
+      return {
+        block: true,
+        reason: (hso["permissionDecisionReason"] as string) ?? "blocked by token-goat",
+      };
+    }
+
+    // Update: rewrite tool args in place (e.g. image-shrunk path, compressed
+    // bash command). token-goat returns its own snake_case keys; map them back.
+    const updated = hso["updatedInput"] as Record<string, unknown> | undefined;
+    if (updated) {
+      const rev = reverseArgMap(event.toolName);
+      for (const [tgKey, val] of Object.entries(updated)) {
+        input[rev[tgKey] ?? tgKey] = val;
+      }
+    }
+  });
+
+  pi.on("tool_result", async (event, _ctx) => {
+    const tg = TOOL_TO_TG[event.toolName];
+    if (!tg) return;
+    callHook(POST_HOOK[tg] ?? "post-read", {
+      session_id: sessionId,
+      tool_name: tg,
+      tool_input: toToolInput(event.toolName, (event.input ?? {}) as Record<string, unknown>),
+      cwd,
+    });
+  });
+
+  // Compaction: pi's session_before_compact REPLACES the summary rather than
+  // appending to it (unlike opencode's additive output.context). So capture the
+  // token-goat manifest here, let pi build its own summary, then inject the
+  // manifest as a post-compaction message that survives into the new context
+  // window. This preserves the edited-file / symbol manifest within pi's
+  // replace-only compaction model.
+  pi.on("session_before_compact", async (_event, _ctx) => {
+    const resp = callHook("pre-compact", { session_id: sessionId, trigger: "auto" });
+    pendingManifest = resp?.["systemMessage"] as string | undefined;
+  });
+
+  pi.on("session_compact", async (_event, _ctx) => {
+    if (pendingManifest) {
+      pi.sendMessage(
+        { customType: "token-goat-manifest", content: pendingManifest, display: false },
+        { deliverAs: "nextTurn" },
+      );
+      pendingManifest = undefined;
+    }
+  });
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Token-Goat are documented in this file. Format follows Ke
 
 ## [Unreleased]
 
+### Added
+
+- **pi (pi-coding-agent) integration via `--pi`.** Adds a TypeScript extension bridge for [pi-coding-agent](https://github.com/earendil-works/pi-mono), following the same pattern as the existing opencode/openclaw bridges. `token-goat install --pi` writes the extension to `~/.pi/agent/extensions/token-goat.ts`; a project-local install (`bridges.install_pi_plugin(target_dir=...)`) writes `<project>/.pi/extensions/token-goat.ts` instead. The extension subscribes to pi's `session_start`, `tool_call`, `tool_result`, `session_before_compact`, and `session_compact` events and forwards them to the existing `token-goat hook <event>` subprocess protocol. So bash compression, re-read denial, image shrinking, surgical-read redirects, post-edit indexing, output caching, and the compaction manifest work inside pi. Compaction differs slightly from opencode: pi replaces the summary rather than appending, so the manifest is captured at `session_before_compact` and re-injected after `session_compact`. Skill-overhead preservation is not included — pi has no Skill tool, since skills are template expansions there. Reverse with `token-goat uninstall --pi`. `pi` is wired into `--target`, `plan_install`, `install_all`, `uninstall_all`, `check_status`, and `detect_installed_harnesses`.
+
 ## [1.9.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ permalink: /
 
 Token-Goat sits silently between your AI and your tools. Re-read a file? It gets a one-line hint and a narrow-slice suggestion instead of the full file again. Grab a screenshot? A 100 KB copy reaches the model instead of 10 MB. Run `pytest`, `npm install`, `docker build`, or `cargo`? The thousands of progress bars and passing-test names are stripped to the failures before the output even reaches the context window. Compact a long session? It gets a clean structured manifest of edited files and key symbols so nothing important is forgotten. Sessions drop 40–90%+ in cost. You change nothing about how you work.
 
-Works with **Claude Code**, **Gemini CLI**, **Codex CLI**, **Aider**, **Cursor**, **Cline**, **Windsurf**, **Copilot CLI**, OpenCode, and OpenClaw.
+Works with **Claude Code**, **Gemini CLI**, **Codex CLI**, **Aider**, **Cursor**, **Cline**, **Windsurf**, **Copilot CLI**, OpenCode, OpenClaw, and **pi** ([pi-coding-agent](https://github.com/earendil-works/pi-mono)).
+
+> **This fork ([`pi-token-goat`](https://github.com/eSaadster/pi-token-goat))** adds a **pi** integration on top of upstream [token-goat](https://github.com/DFKHelper/token-goat): a TypeScript extension bridges pi's extension events (`tool_call`, `tool_result`, `session_before_compact`, …) into token-goat's hook engine, so bash compression, surgical-read routing, re-read denial, image shrinking, post-edit indexing, and the compaction manifest all work inside pi. See [pi users](#pi-users).
 
 **Ask your AI to install it fully (give it this GitHub link), or install in one command (install UV first if needed):**
 
@@ -290,6 +292,24 @@ token-goat install --openclaw
 
 The `--openclaw` flag patches Claude Code and drops a TypeScript bridge plugin into `~/.openclaw/plugins/` and registers it in `openclaw.json` — one command, no separate base install. Image shrinking, post-edit indexing, and pre-fetch denial work. Session hints and compact assist don't — no context injection point, no compaction event.
 
+### pi users
+
+```
+token-goat install --pi
+```
+
+The `--pi` flag patches Claude Code and drops a TypeScript extension into pi's global extensions directory (`~/.pi/agent/extensions/token-goat.ts`). pi auto-discovers it on the next launch (approve the project-trust prompt the first time). The extension is a normal pi extension — a default-exported factory that subscribes to `session_start`, `tool_call`, `tool_result`, `session_before_compact`, and `session_compact` — and bridges those events into token-goat's `token-goat hook <event>` subprocess protocol.
+
+What works: **bash output compression** (the bash command is rewritten in `tool_call`), **re-read denial** (`tool_call` returns `{ block, reason }` for confirmed re-reads), **image shrinking** and **surgical-read redirects** (args rewritten in place), **post-edit indexing** and **output caching** (`tool_result`), and the **compaction manifest** (captured at `session_before_compact`, re-injected after `session_compact` since pi's compaction replaces rather than appends). Skill-overhead preservation does not apply — pi has no Skill tool; skills are template expansions. To remove: `token-goat uninstall --pi`.
+
+**Project-local install (single project only).** pi also loads extensions from a project's `.pi/extensions/` directory (after the project is trusted). To install for one project without touching the global directory, drop the extension there:
+
+```
+python -c "from token_goat import bridges; from pathlib import Path; bridges.install_pi_plugin(target_dir=Path('.pi/extensions').resolve())"
+```
+
+This writes `.pi/extensions/token-goat.ts` in the current project only. Remove it by deleting that file.
+
 ### Cline, Windsurf, Cursor, Copilot CLI, and other AI tool CLIs
 
 No separate install step needed. Token-goat compresses the terminal output of these tools automatically as soon as they appear on your PATH. Run `token-goat doctor` to confirm they are detected — the "Third-party AI tools" section will show `detected — bash output compression active`.
@@ -439,6 +459,12 @@ Contains the symbol index (`global.db`, per-project `.db` files), session cache,
 |------|------|
 | `~/.openclaw/plugins/token-goat-bridge.ts` | TypeScript bridge plugin. Fires on `before_tool_call` and `after_tool_call`. Covers image shrinking, post-edit indexing, and pre-fetch denial. |
 | `~/.openclaw/openclaw.json` | Plugin entry added under `plugins.entries`. Existing entries preserved. |
+
+**With `--pi`** (pi extension)
+
+| Path | What |
+|------|------|
+| `~/.pi/agent/extensions/token-goat.ts` | TypeScript extension (default-exported `ExtensionAPI` factory). Subscribes to `session_start`, `tool_call`, `tool_result`, `session_before_compact`, and `session_compact`. Covers bash compression, re-read denial, image shrinking, surgical-read redirects, post-edit indexing, output caching, and the compaction manifest. A project-local install writes `<project>/.pi/extensions/token-goat.ts` instead. |
 
 ## Zero maintenance
 
@@ -734,7 +760,7 @@ Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\dfk-helper\token-goat"
 token-goat uninstall
 ```
 
-Reverses everything in [What gets installed?](#what-gets-installed): the scheduled task or systemd unit, the registry value or `.desktop` or `.plist`, the hook entries in `settings.json`, the `CLAUDE.md` block, the skill directory. Add `--codex`, `--gemini`, `--opencode`, or `--openclaw` to also strip those integrations. Add `--purge` to also delete the data directory (cache, index, models, logs). Nothing else on the system depends on it.
+Reverses everything in [What gets installed?](#what-gets-installed): the scheduled task or systemd unit, the registry value or `.desktop` or `.plist`, the hook entries in `settings.json`, the `CLAUDE.md` block, the skill directory. Add `--codex`, `--gemini`, `--opencode`, `--openclaw`, or `--pi` to also strip those integrations. Add `--purge` to also delete the data directory (cache, index, models, logs). Nothing else on the system depends on it.
 
 ## About
 

--- a/src/token_goat/bridges.py
+++ b/src/token_goat/bridges.py
@@ -8,19 +8,27 @@ Supported harnesses
 opencode  — sst/opencode in-process plugin system; hooks via tool.execute.before/after
             and experimental.session.compacting.
 openclaw  — openclawlab plugin system; hooks via before_tool_call / after_tool_call.
+pi        — earendil-works/pi-coding-agent extension system; a default-exported
+            factory that subscribes to session_start / tool_call / tool_result /
+            session_before_compact / session_compact via the ExtensionAPI.
 """
 from __future__ import annotations
 
 __all__ = [
-    "OPENCODE_PLUGIN_TS",
     "OPENCLAW_PLUGIN_TS",
+    "OPENCODE_PLUGIN_TS",
+    "PI_EXTENSION_TS",
     "install_openclaw_plugin",
     "install_opencode_plugin",
+    "install_pi_plugin",
     "openclaw_config_path",
     "openclaw_plugins_dir",
     "opencode_plugins_dir",
+    "pi_extensions_dir",
+    "pi_plugin_path",
     "uninstall_openclaw_plugin",
     "uninstall_opencode_plugin",
+    "uninstall_pi_plugin",
 ]
 
 import json
@@ -337,6 +345,165 @@ export default {
 };
 """
 
+PI_EXTENSION_TS = """\
+// token-goat bridge extension for pi (pi-coding-agent)
+// Bridges pi's extension events to token-goat's subprocess hook protocol.
+// https://github.com/DFKHelper/token-goat
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawnSync } from "node:child_process";
+
+// pi built-in tool names -> token-goat internal tool names
+const TOOL_TO_TG: Record<string, string> = {
+  read: "Read",
+  bash: "Bash",
+  edit: "Edit",
+  write: "Write",
+  grep: "Grep",
+  find: "Glob",
+};
+
+// pi tool args (camelCase/short) -> token-goat snake_case tool_input keys
+const ARGS_TO_TG: Record<string, Record<string, string>> = {
+  read: { path: "file_path", offset: "offset", limit: "limit" },
+  bash: { command: "command", timeout: "timeout" },
+  edit: { path: "file_path" },
+  write: { path: "file_path" },
+  grep: { pattern: "pattern", path: "path" },
+  find: { pattern: "pattern", path: "path" },
+};
+
+// Post-call hook event per token-goat tool name
+const POST_HOOK: Record<string, string> = {
+  Read: "post-read",
+  Grep: "post-read",
+  Glob: "post-read",
+  Bash: "post-bash",
+  WebFetch: "post-fetch",
+  Edit: "post-edit",
+  Write: "post-edit",
+};
+
+// Tools that have a pre-hook (read/search/fetch types only).
+// Edit/Write tools have no pre-hook in token-goat; skip before-dispatch for them.
+const PRE_HOOK_TOOLS = new Set(["Read", "Grep", "Glob", "Bash", "WebFetch"]);
+
+function callHook(event: string, payload: Record<string, unknown>): Record<string, unknown> | null {
+  try {
+    const r = spawnSync("token-goat", ["hook", event], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      timeout: 5000,
+      windowsHide: true,
+    });
+    if (r.error) return null;
+    const out = r.stdout?.trim();
+    if (!out) return null;
+    return JSON.parse(out) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function reverseArgMap(tool: string): Record<string, string> {
+  const fwd = ARGS_TO_TG[tool] ?? {};
+  return Object.fromEntries(Object.entries(fwd).map(([piKey, tgKey]) => [tgKey, piKey]));
+}
+
+function toToolInput(tool: string, input: Record<string, unknown>): Record<string, unknown> {
+  const argMap = ARGS_TO_TG[tool] ?? {};
+  const out: Record<string, unknown> = {};
+  for (const [piKey, tgKey] of Object.entries(argMap)) {
+    if (input[piKey] !== undefined) out[tgKey] = input[piKey];
+  }
+  return out;
+}
+
+export default function (pi: ExtensionAPI) {
+  // Stable per-session id derived from pi's session file (filesystem-safe), or
+  // a process-scoped fallback for ephemeral sessions. Recomputed on every
+  // session_start (new / resume / fork all re-fire it).
+  let sessionId = `pi-${process.pid}`;
+  let cwd = process.cwd();
+  // Manifest captured at session_before_compact, injected after compaction.
+  let pendingManifest: string | undefined;
+
+  pi.on("session_start", (_event, ctx) => {
+    cwd = ctx.cwd ?? process.cwd();
+    const file = ctx.sessionManager?.getSessionFile?.();
+    sessionId = file ? `pi-${file.replace(/[^A-Za-z0-9._-]/g, "_")}` : `pi-${process.pid}`;
+    callHook("session-start", { session_id: sessionId, cwd });
+  });
+
+  pi.on("tool_call", async (event, _ctx) => {
+    const tg = TOOL_TO_TG[event.toolName];
+    if (!tg || !PRE_HOOK_TOOLS.has(tg)) return;
+
+    const input = event.input as Record<string, unknown>;
+    const hookEvent = tg === "WebFetch" ? "pre-fetch" : "pre-read";
+    const resp = callHook(hookEvent, {
+      session_id: sessionId,
+      tool_name: tg,
+      tool_input: toToolInput(event.toolName, input),
+      cwd,
+    });
+    if (!resp) return;
+
+    const hso = resp["hookSpecificOutput"] as Record<string, unknown> | undefined;
+    if (!hso) return;
+
+    // Deny: block the tool call with a reason (e.g. confirmed re-read).
+    if (hso["permissionDecision"] === "deny") {
+      return {
+        block: true,
+        reason: (hso["permissionDecisionReason"] as string) ?? "blocked by token-goat",
+      };
+    }
+
+    // Update: rewrite tool args in place (e.g. image-shrunk path, compressed
+    // bash command). token-goat returns its own snake_case keys; map them back.
+    const updated = hso["updatedInput"] as Record<string, unknown> | undefined;
+    if (updated) {
+      const rev = reverseArgMap(event.toolName);
+      for (const [tgKey, val] of Object.entries(updated)) {
+        input[rev[tgKey] ?? tgKey] = val;
+      }
+    }
+  });
+
+  pi.on("tool_result", async (event, _ctx) => {
+    const tg = TOOL_TO_TG[event.toolName];
+    if (!tg) return;
+    callHook(POST_HOOK[tg] ?? "post-read", {
+      session_id: sessionId,
+      tool_name: tg,
+      tool_input: toToolInput(event.toolName, (event.input ?? {}) as Record<string, unknown>),
+      cwd,
+    });
+  });
+
+  // Compaction: pi's session_before_compact REPLACES the summary rather than
+  // appending to it (unlike opencode's additive output.context). So capture the
+  // token-goat manifest here, let pi build its own summary, then inject the
+  // manifest as a post-compaction message that survives into the new context
+  // window. This preserves the edited-file / symbol manifest within pi's
+  // replace-only compaction model.
+  pi.on("session_before_compact", async (_event, _ctx) => {
+    const resp = callHook("pre-compact", { session_id: sessionId, trigger: "auto" });
+    pendingManifest = resp?.["systemMessage"] as string | undefined;
+  });
+
+  pi.on("session_compact", async (_event, _ctx) => {
+    if (pendingManifest) {
+      pi.sendMessage(
+        { customType: "token-goat-manifest", content: pendingManifest, display: false },
+        { deliverAs: "nextTurn" },
+      );
+      pendingManifest = undefined;
+    }
+  });
+}
+"""
+
 # ---------------------------------------------------------------------------
 # Shared file-level install / uninstall helpers
 # ---------------------------------------------------------------------------
@@ -389,6 +556,26 @@ def openclaw_plugins_dir() -> Path:
 def openclaw_config_path() -> Path:
     """Return the openclaw config file path (~/.openclaw/openclaw.json)."""
     return Path.home() / ".openclaw" / "openclaw.json"
+
+
+def pi_extensions_dir() -> Path:
+    """Return the global pi extensions directory (~/.pi/agent/extensions).
+
+    pi auto-discovers extensions from this user/global location.  Project-local
+    installs target ``<project>/.pi/extensions`` instead — pass that path as the
+    ``target_dir`` argument to :func:`install_pi_plugin`.
+    """
+    return Path.home() / ".pi" / "agent" / "extensions"
+
+
+def pi_plugin_path(target_dir: Path | None = None) -> Path:
+    """Return the path the pi bridge extension is (or would be) written to.
+
+    Defaults to the global :func:`pi_extensions_dir`; pass *target_dir* for a
+    project-local install directory.
+    """
+    dest = target_dir if target_dir is not None else pi_extensions_dir()
+    return dest / _PI_FILENAME
 
 
 # ---------------------------------------------------------------------------
@@ -554,3 +741,37 @@ def _check_openclaw_plugin() -> str:
     if registered and not file_installed:
         return "registered in openclaw.json but plugin file missing"
     return "not installed"
+
+
+# ---------------------------------------------------------------------------
+# Pi install / uninstall / check
+# ---------------------------------------------------------------------------
+
+_PI_FILENAME = "token-goat.ts"
+
+
+def install_pi_plugin(target_dir: Path | None = None) -> str:
+    """Write the pi bridge extension. Returns the path.
+
+    *target_dir* overrides the destination directory.  Defaults to the global
+    :func:`pi_extensions_dir` (``~/.pi/agent/extensions``); pass a project-local
+    ``<project>/.pi/extensions`` path to install for a single project only
+    (pi loads project-local extensions after the project is trusted).
+    """
+    dest = target_dir if target_dir is not None else pi_extensions_dir()
+    plugin_path = _write_plugin_file(dest, _PI_FILENAME, PI_EXTENSION_TS)
+    _LOG.info("pi extension written: %s", plugin_path)
+    return str(plugin_path)
+
+
+def uninstall_pi_plugin(target_dir: Path | None = None) -> str:
+    """Remove the pi bridge extension. Returns a status string.
+
+    *target_dir* must match the directory used at install time (default global).
+    """
+    return _remove_plugin_file(pi_plugin_path(target_dir))
+
+
+def _check_pi_plugin(target_dir: Path | None = None) -> str:
+    """Return install status of the pi bridge extension (default global dir)."""
+    return _check_plugin_file(pi_plugin_path(target_dir))

--- a/src/token_goat/cli.py
+++ b/src/token_goat/cli.py
@@ -6145,7 +6145,7 @@ def doctor(  # noqa: C901
     cli_doctor.doctor(fix=fix, crashes=False, context=context)
 
 
-_VALID_TARGETS = {"claude", "codex", "gemini", "opencode", "openclaw", "all"}
+_VALID_TARGETS = {"claude", "codex", "gemini", "opencode", "openclaw", "pi", "all"}
 
 
 @app.command("context-stats", rich_help_panel="Install")
@@ -6182,13 +6182,14 @@ def cmd_install(
     codex: bool = typer.Option(False, "--codex", help="Also install Codex CLI integration"),  # noqa: B008
     opencode: bool = typer.Option(False, "--opencode", help="Also install opencode plugin bridge"),  # noqa: B008
     openclaw: bool = typer.Option(False, "--openclaw", help="Also install openclaw plugin bridge"),  # noqa: B008
+    pi: bool = typer.Option(False, "--pi", help="Also install pi extension bridge (global ~/.pi/agent/extensions)"),  # noqa: B008
     target: list[str] = typer.Option(  # noqa: B008
         None,
         "--target",
         help=(
             "Install hooks for a specific tool. May be repeated. "
-            "Choices: claude, codex, gemini, opencode, openclaw, all. "
-            "Overrides --codex/--opencode/--openclaw when provided."
+            "Choices: claude, codex, gemini, opencode, openclaw, pi, all. "
+            "Overrides --codex/--opencode/--openclaw/--pi when provided."
         ),
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print what would change; make no changes"),  # noqa: B008
@@ -6248,6 +6249,7 @@ def cmd_install(
             install_codex=codex,
             install_opencode=opencode,
             install_openclaw=openclaw,
+            install_pi=pi,
             targets=targets,
         )
         typer.echo("token-goat install --dry-run (no changes made):")
@@ -6273,6 +6275,7 @@ def cmd_install(
         install_codex=codex,
         install_opencode=opencode,
         install_openclaw=openclaw,
+        install_pi=pi,
         targets=targets,
     )
     typer.echo("token-goat install:")
@@ -6318,11 +6321,12 @@ def cmd_uninstall(
     gemini: bool = typer.Option(False, "--gemini", help="Also remove Gemini CLI hook integration"),  # noqa: B008
     opencode: bool = typer.Option(False, "--opencode", help="Also remove opencode plugin bridge"),  # noqa: B008
     openclaw: bool = typer.Option(False, "--openclaw", help="Also remove openclaw plugin bridge"),  # noqa: B008
+    pi: bool = typer.Option(False, "--pi", help="Also remove pi extension bridge (global ~/.pi/agent/extensions)"),  # noqa: B008
 ) -> None:
     """Cleanly reverse install."""
     from . import install as inst  # noqa: PLC0415
 
-    result = inst.uninstall_all(purge=purge, codex=codex, gemini=gemini, opencode=opencode, openclaw=openclaw)
+    result = inst.uninstall_all(purge=purge, codex=codex, gemini=gemini, opencode=opencode, openclaw=openclaw, pi=pi)
     typer.echo("token-goat uninstall:")
     for step, detail in result.items():
         typer.echo(f"  {step}: {detail}")

--- a/src/token_goat/install.py
+++ b/src/token_goat/install.py
@@ -2355,6 +2355,7 @@ def detect_installed_harnesses() -> dict[str, bool]:
     - ``gemini``  — detected when ``~/.gemini/`` exists (Gemini CLI stores its config there).
     - ``opencode`` — detected when the opencode plugins dir exists.
     - ``openclaw`` — detected when ``~/.openclaw/`` exists.
+    - ``pi``       — detected when ``~/.pi/`` exists (pi-coding-agent config dir).
     - ``cline``    — detected when the ``cline`` or ``claude-dev`` binary is on PATH or package is importable.
     - ``windsurf`` — detected when ``windsurf`` binary is on PATH or config dir exists.
     - ``copilot-cli`` — detected when ``copilot`` or ``github-copilot-cli`` binary is on PATH.
@@ -2381,9 +2382,11 @@ def detect_installed_harnesses() -> dict[str, bool]:
 
         result["opencode"] = _br.opencode_plugins_dir().parent.exists()
         result["openclaw"] = (Path.home() / ".openclaw").exists()
+        result["pi"] = (Path.home() / ".pi").exists()
     except Exception:  # noqa: BLE001
         result["opencode"] = False
         result["openclaw"] = False
+        result["pi"] = False
 
     # Other harnesses
     result["cline"] = detect_cline()
@@ -2435,6 +2438,7 @@ def check_status() -> dict[str, str]:
     from . import bridges  # noqa: PLC0415
     status["opencode plugin"] = bridges._check_opencode_plugin()
     status["openclaw plugin"] = bridges._check_openclaw_plugin()
+    status["pi plugin"] = bridges._check_pi_plugin()
     return status
 
 
@@ -2585,6 +2589,7 @@ def plan_install(
     install_codex: bool = False,
     install_opencode: bool = False,
     install_openclaw: bool = False,
+    install_pi: bool = False,
     targets: set[str] | None = None,
 ) -> list[_PlanEntry]:
     """Return what :func:`install_all` *would* do, without making any changes.
@@ -2601,11 +2606,12 @@ def plan_install(
     """
     install_gemini = False
     if targets is not None:
-        effective = targets if "all" not in targets else {"claude", "codex", "gemini", "opencode", "openclaw"}
+        effective = targets if "all" not in targets else {"claude", "codex", "gemini", "opencode", "openclaw", "pi"}
         install_codex = "codex" in effective
         install_gemini = "gemini" in effective
         install_opencode = "opencode" in effective
         install_openclaw = "openclaw" in effective
+        install_pi = "pi" in effective
     plan: list[_PlanEntry] = []
 
     # 1. settings.json
@@ -2771,8 +2777,8 @@ def plan_install(
             detail=detail,
         ))
 
-    # 7. optional opencode / openclaw
-    if install_opencode or install_openclaw:
+    # 7. optional opencode / openclaw / pi
+    if install_opencode or install_openclaw or install_pi:
         try:
             from . import bridges  # noqa: PLC0415
         except Exception as e:  # noqa: BLE001
@@ -2796,6 +2802,13 @@ def plan_install(
                 target=str(getattr(bridges, "openclaw_plugin_path", lambda: "<unknown>")()),
                 action="create",
                 detail="would write/refresh TS shim",
+            ))
+        if install_pi and bridges is not None:
+            plan.append(_PlanEntry(
+                component="pi: extension",
+                target=str(getattr(bridges, "pi_plugin_path", lambda: "<unknown>")()),
+                action="create",
+                detail="would write/refresh TS extension",
             ))
 
     return plan
@@ -2952,31 +2965,38 @@ def install_all(
     install_codex: bool = False,
     install_opencode: bool = False,
     install_openclaw: bool = False,
+    install_pi: bool = False,
     targets: set[str] | None = None,
 ) -> dict[str, str]:
     """Run the full install. Returns a dict of step -> result string.
 
     *targets* is an optional set of tool names (``claude``, ``codex``,
-    ``opencode``, ``openclaw``, ``all``).  When provided it overrides the
+    ``opencode``, ``openclaw``, ``pi``, ``all``).  When provided it overrides the
     individual boolean flags: passing ``targets={"codex"}`` is equivalent to
     ``install_codex=True`` with all other booleans at their defaults.
     ``targets={"all"}`` enables every optional integration.
     When *targets* is ``None`` the legacy boolean flags are honoured unchanged.
+
+    The ``pi`` target installs the bridge into the global pi extensions
+    directory (``~/.pi/agent/extensions``).  For a project-local install, call
+    :func:`token_goat.bridges.install_pi_plugin` with a ``target_dir`` directly.
     """
     install_gemini = False
     if targets is not None:
-        effective = targets if "all" not in targets else {"claude", "codex", "gemini", "opencode", "openclaw"}
+        effective = targets if "all" not in targets else {"claude", "codex", "gemini", "opencode", "openclaw", "pi"}
         install_codex = "codex" in effective
         install_gemini = "gemini" in effective
         install_opencode = "opencode" in effective
         install_openclaw = "openclaw" in effective
+        install_pi = "pi" in effective
     t0 = time.monotonic()
     _LOG.info(
-        "install_all: starting (platform=%s codex=%s opencode=%s openclaw=%s targets=%s)",
+        "install_all: starting (platform=%s codex=%s opencode=%s openclaw=%s pi=%s targets=%s)",
         sys.platform,
         install_codex,
         install_opencode,
         install_openclaw,
+        install_pi,
         targets,
     )
     paths.ensure_dirs()
@@ -3037,7 +3057,7 @@ def install_all(
     if install_gemini:
         _run_step(result, "gemini: hooks", patch_gemini_settings)
 
-    if install_opencode or install_openclaw:
+    if install_opencode or install_openclaw or install_pi:
         from . import bridges  # noqa: PLC0415
 
     if install_opencode:
@@ -3045,6 +3065,9 @@ def install_all(
 
     if install_openclaw:
         _run_step(result, "openclaw: plugin", bridges.install_openclaw_plugin)
+
+    if install_pi:
+        _run_step(result, "pi: extension", bridges.install_pi_plugin)
 
     codec_report = probe_image_codecs()
     result["image codecs"] = (
@@ -3162,17 +3185,19 @@ def uninstall_all(
     gemini: bool = False,
     opencode: bool = False,
     openclaw: bool = False,
+    pi: bool = False,
 ) -> dict[str, str]:
     """Reverse install. With purge=True also deletes the data directory."""
     t0 = time.monotonic()
     _LOG.info(
-        "uninstall_all: starting (platform=%s purge=%s codex=%s gemini=%s opencode=%s openclaw=%s)",
+        "uninstall_all: starting (platform=%s purge=%s codex=%s gemini=%s opencode=%s openclaw=%s pi=%s)",
         sys.platform,
         purge,
         codex,
         gemini,
         opencode,
         openclaw,
+        pi,
     )
     result: dict[str, str] = {}
 
@@ -3206,7 +3231,7 @@ def uninstall_all(
     if gemini:
         result["gemini: hooks"] = _ok_fail(True, f"unpatched — {unpatch_gemini_settings()}")
 
-    if opencode or openclaw:
+    if opencode or openclaw or pi:
         from . import bridges  # noqa: PLC0415
 
     if opencode:
@@ -3214,6 +3239,9 @@ def uninstall_all(
 
     if openclaw:
         result["openclaw: plugin"] = bridges.uninstall_openclaw_plugin()
+
+    if pi:
+        result["pi: extension"] = bridges.uninstall_pi_plugin()
 
     failures = [k for k, v in result.items() if v.startswith("FAIL")]
     elapsed_ms = (time.monotonic() - t0) * 1000

--- a/tests/test_bridges.py
+++ b/tests/test_bridges.py
@@ -243,6 +243,88 @@ class TestPluginTsSources:
             f"Expected exactly 1 output.context.push call (guarded), found {push_count}"
         )
 
+    # --- pi extension TS source smoke checks ---
+
+    def test_pi_ts_contains_spawnSync(self) -> None:
+        assert "spawnSync" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_contains_token_goat(self) -> None:
+        assert "token-goat" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_exports_default_factory(self) -> None:
+        assert "export default function" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_imports_extension_api(self) -> None:
+        # The factory's single argument is typed against pi's ExtensionAPI.
+        assert "ExtensionAPI" in bridges.PI_EXTENSION_TS
+        assert "@earendil-works/pi-coding-agent" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_subscribes_session_start(self) -> None:
+        assert 'pi.on("session_start"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_subscribes_tool_call(self) -> None:
+        assert 'pi.on("tool_call"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_subscribes_tool_result(self) -> None:
+        assert 'pi.on("tool_result"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_subscribes_compaction_events(self) -> None:
+        assert 'pi.on("session_before_compact"' in bridges.PI_EXTENSION_TS
+        assert 'pi.on("session_compact"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_maps_read_tool(self) -> None:
+        # TS object keys are unquoted: `read: "Read",`
+        assert 'read: "Read"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_maps_find_to_glob(self) -> None:
+        # pi's find tool is the glob-equivalent.
+        assert 'find: "Glob"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_has_deny_support(self) -> None:
+        assert "block: true" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_has_updated_input_support(self) -> None:
+        assert "updatedInput" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_bash_routes_to_post_bash(self) -> None:
+        assert 'Bash: "post-bash"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_post_edit_for_write(self) -> None:
+        assert 'Write: "post-edit"' in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_has_post_hook_table(self) -> None:
+        assert "POST_HOOK" in bridges.PI_EXTENSION_TS
+        assert "POST_HOOK[tg]" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_has_pre_hook_tools_guard(self) -> None:
+        assert "PRE_HOOK_TOOLS" in bridges.PI_EXTENSION_TS
+        assert "PRE_HOOK_TOOLS.has(tg)" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_pre_hook_tools_excludes_edit(self) -> None:
+        match = re.search(r'const PRE_HOOK_TOOLS = new Set\(\[([^\]]+)\]\)', bridges.PI_EXTENSION_TS)
+        assert match, "PRE_HOOK_TOOLS Set literal not found in PI_EXTENSION_TS"
+        members = match.group(1)
+        assert '"Edit"' not in members
+        assert '"Write"' not in members
+        assert '"Read"' in members
+        assert '"Bash"' in members
+
+    def test_pi_ts_callhook_checks_r_error(self) -> None:
+        assert "r.error" in bridges.PI_EXTENSION_TS
+
+    def test_pi_ts_callhook_error_before_stdout(self) -> None:
+        pts = bridges.PI_EXTENSION_TS
+        error_pos = pts.find("r.error")
+        stdout_pos = pts.find("r.stdout")
+        assert error_pos != -1 and stdout_pos != -1
+        assert error_pos < stdout_pos, "r.error check must precede r.stdout access"
+
+    def test_pi_ts_no_backslash_escapes(self) -> None:
+        # The TS is embedded in a plain (non-raw) Python triple-quoted string.
+        # Backslashes would risk invalid-escape SyntaxWarnings and corrupted
+        # regex, so the source must avoid them entirely.
+        assert "\\" not in bridges.PI_EXTENSION_TS
+
 
 # ---------------------------------------------------------------------------
 # Bridge TS event-table alignment with hook_registry
@@ -293,27 +375,40 @@ class TestBridgeEventRegistryAlignment:
             f"Canonical events: {sorted(canonical)}"
         )
 
+    def test_pi_events_all_registered(self) -> None:
+        canonical = set(hook_registry.all_events())
+        bridge_events = _extract_bridge_events(bridges.PI_EXTENSION_TS)
+        assert bridge_events, "regex found no event names in PI_EXTENSION_TS — pattern may need update"
+        unknown = bridge_events - canonical
+        assert not unknown, (
+            f"PI_EXTENSION_TS references event(s) not in hook_registry: {sorted(unknown)}\n"
+            f"Canonical events: {sorted(canonical)}"
+        )
+
     def test_combined_bridge_events_cover_common_subset(self) -> None:
         """Each bridge must reference the core events appropriate for its harness.
 
-        opencode has compaction support (experimental.session.compacting), so it
-        must include pre-compact.  openclaw has no compaction API, so pre-compact
-        is intentionally absent there.
+        opencode and pi have compaction support, so they must include
+        pre-compact.  openclaw has no compaction API, so pre-compact is
+        intentionally absent there.
         """
         # Events required in both bridges (common integration surface)
         shared_core = {"session-start", "pre-read", "pre-fetch", "post-edit", "post-bash"}
         # Events only required where the harness supports them
-        opencode_only = {"pre-compact"}
+        compaction_bridges = {"pre-compact"}
 
         opencode_events = _extract_bridge_events(bridges.OPENCODE_PLUGIN_TS)
         openclaw_events = _extract_bridge_events(bridges.OPENCLAW_PLUGIN_TS)
+        pi_events = _extract_bridge_events(bridges.PI_EXTENSION_TS)
 
         for event in shared_core:
             assert event in opencode_events, f"shared core event '{event}' missing from OPENCODE_PLUGIN_TS"
             assert event in openclaw_events, f"shared core event '{event}' missing from OPENCLAW_PLUGIN_TS"
+            assert event in pi_events, f"shared core event '{event}' missing from PI_EXTENSION_TS"
 
-        for event in opencode_only:
-            assert event in opencode_events, f"opencode-only event '{event}' missing from OPENCODE_PLUGIN_TS"
+        for event in compaction_bridges:
+            assert event in opencode_events, f"compaction event '{event}' missing from OPENCODE_PLUGIN_TS"
+            assert event in pi_events, f"compaction event '{event}' missing from PI_EXTENSION_TS"
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +486,19 @@ class TestPathHelpers:
     def test_openclaw_config_path(self) -> None:
         result = bridges.openclaw_config_path()
         assert result == Path.home() / ".openclaw" / "openclaw.json"
+
+    def test_pi_extensions_dir(self) -> None:
+        result = bridges.pi_extensions_dir()
+        assert result == Path.home() / ".pi" / "agent" / "extensions"
+
+    def test_pi_plugin_path_default(self) -> None:
+        result = bridges.pi_plugin_path()
+        assert result == bridges.pi_extensions_dir() / bridges._PI_FILENAME
+
+    def test_pi_plugin_path_target_dir(self, tmp_path: Path) -> None:
+        target = tmp_path / "proj" / ".pi" / "extensions"
+        result = bridges.pi_plugin_path(target)
+        assert result == target / bridges._PI_FILENAME
 
 
 # ---------------------------------------------------------------------------
@@ -630,6 +738,94 @@ class TestOpenclawPlugin:
 
 
 # ---------------------------------------------------------------------------
+# Pi install / uninstall / check
+# ---------------------------------------------------------------------------
+
+
+class TestPiPlugin:
+    def test_install_writes_file(self, tmp_path: Path) -> None:
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path / "extensions"):
+            path_str = bridges.install_pi_plugin()
+        written = Path(path_str)
+        assert written.exists()
+        assert written.read_text(encoding="utf-8") == bridges.PI_EXTENSION_TS
+
+    def test_install_creates_parent_dirs(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "extensions"
+        with patch.object(bridges, "pi_extensions_dir", return_value=nested):
+            bridges.install_pi_plugin()
+        assert nested.exists()
+
+    def test_install_returns_path_string(self, tmp_path: Path) -> None:
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            result = bridges.install_pi_plugin()
+        assert isinstance(result, str)
+        assert "token-goat.ts" in result
+
+    def test_install_target_dir_overrides_global(self, tmp_path: Path) -> None:
+        # Project-local install: target_dir wins over pi_extensions_dir().
+        proj = tmp_path / "proj" / ".pi" / "extensions"
+        global_dir = tmp_path / "global"
+        with patch.object(bridges, "pi_extensions_dir", return_value=global_dir):
+            path_str = bridges.install_pi_plugin(target_dir=proj)
+        assert Path(path_str) == proj / bridges._PI_FILENAME
+        assert (proj / bridges._PI_FILENAME).exists()
+        assert not global_dir.exists()
+
+    def test_install_is_idempotent(self, tmp_path: Path) -> None:
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            bridges.install_pi_plugin()
+            bridges.install_pi_plugin()
+        assert (tmp_path / bridges._PI_FILENAME).exists()
+
+    def test_uninstall_removes_file(self, tmp_path: Path) -> None:
+        plugin_path = tmp_path / bridges._PI_FILENAME
+        _write_fake_plugin(plugin_path, bridges.PI_EXTENSION_TS)
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            result = bridges.uninstall_pi_plugin()
+        assert not plugin_path.exists()
+        assert "removed" in result
+
+    def test_uninstall_target_dir(self, tmp_path: Path) -> None:
+        proj = tmp_path / "proj" / ".pi" / "extensions"
+        bridges.install_pi_plugin(target_dir=proj)
+        result = bridges.uninstall_pi_plugin(target_dir=proj)
+        assert "removed" in result
+        assert not (proj / bridges._PI_FILENAME).exists()
+
+    def test_uninstall_not_found(self, tmp_path: Path) -> None:
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            result = bridges.uninstall_pi_plugin()
+        assert result == "not found"
+
+    def test_check_not_installed(self, tmp_path: Path) -> None:
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            result = bridges._check_pi_plugin()
+        assert result == "not installed"
+
+    def test_check_installed(self, tmp_path: Path) -> None:
+        plugin_path = tmp_path / bridges._PI_FILENAME
+        _write_fake_plugin(plugin_path, bridges.PI_EXTENSION_TS)
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            result = bridges._check_pi_plugin()
+        assert result == "installed"
+
+    def test_check_foreign_file(self, tmp_path: Path) -> None:
+        plugin_path = tmp_path / bridges._PI_FILENAME
+        _write_fake_plugin(plugin_path, "// some other extension")
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            result = bridges._check_pi_plugin()
+        assert "not token-goat bridge" in result
+
+    def test_check_after_install_uninstall(self, tmp_path: Path) -> None:
+        with patch.object(bridges, "pi_extensions_dir", return_value=tmp_path):
+            bridges.install_pi_plugin()
+            assert bridges._check_pi_plugin() == "installed"
+            bridges.uninstall_pi_plugin()
+            assert bridges._check_pi_plugin() == "not installed"
+
+
+# ---------------------------------------------------------------------------
 # install.py integration: check_status, install_all, uninstall_all
 # ---------------------------------------------------------------------------
 
@@ -658,6 +854,97 @@ class TestInstallIntegration:
         ):
             status = install.check_status()
         assert "openclaw plugin" in status
+
+    def test_check_status_includes_pi(self) -> None:
+        from token_goat import install
+
+        with (
+            patch.object(install, "_check_codex_config", return_value="not installed"),
+            patch.object(bridges, "_check_opencode_plugin", return_value="not installed"),
+            patch.object(bridges, "_check_openclaw_plugin", return_value="not installed"),
+            patch.object(bridges, "_check_pi_plugin", return_value="not installed"),
+        ):
+            status = install.check_status()
+        assert "pi plugin" in status
+
+    def test_install_all_pi_called_when_flag_set(self) -> None:
+        from token_goat import install
+
+        with (
+            patch.object(bridges, "install_pi_plugin", return_value="/fake/path") as mock_install,
+            patch.object(install, "patch_settings_json", return_value=(True, "ok")),
+            patch.object(install, "patch_claude_md", return_value="ok"),
+            patch.object(install, "write_skill", return_value="ok"),
+            patch.object(install, "_remove_legacy_launchers", return_value=[]),
+            patch("token_goat.worker.ensure_running", return_value=0),
+            _patch_platform_installs(install),
+        ):
+            result = install.install_all(install_pi=True)
+        mock_install.assert_called_once()
+        assert "pi: extension" in result
+        assert "ok" in result["pi: extension"]
+
+    def test_install_all_pi_via_target(self) -> None:
+        from token_goat import install
+
+        with (
+            patch.object(bridges, "install_pi_plugin", return_value="/fake/path") as mock_install,
+            patch.object(install, "patch_settings_json", return_value=(True, "ok")),
+            patch.object(install, "patch_claude_md", return_value="ok"),
+            patch.object(install, "write_skill", return_value="ok"),
+            patch.object(install, "_remove_legacy_launchers", return_value=[]),
+            patch("token_goat.worker.ensure_running", return_value=0),
+            _patch_platform_installs(install),
+        ):
+            result = install.install_all(targets={"pi"})
+        mock_install.assert_called_once()
+        assert "pi: extension" in result
+
+    def test_install_all_pi_not_called_without_flag(self) -> None:
+        from token_goat import install
+
+        with (
+            patch.object(bridges, "install_pi_plugin") as mock_pi,
+            patch.object(install, "patch_settings_json", return_value=(True, "ok")),
+            patch.object(install, "patch_claude_md", return_value="ok"),
+            patch.object(install, "write_skill", return_value="ok"),
+            patch.object(install, "_remove_legacy_launchers", return_value=[]),
+            patch("token_goat.worker.ensure_running", return_value=0),
+            _patch_platform_installs(install),
+        ):
+            install.install_all()
+        mock_pi.assert_not_called()
+
+    def test_uninstall_all_pi_called_when_flag_set(self) -> None:
+        from token_goat import install
+
+        with (
+            patch.object(bridges, "uninstall_pi_plugin", return_value="removed") as mock_un,
+            patch.object(install, "_stop_worker", return_value="stopped"),
+            patch.object(install, "unpatch_settings_json", return_value="ok"),
+            patch.object(install, "unpatch_claude_md", return_value="ok"),
+            patch.object(install, "remove_skill", return_value="ok"),
+            patch.object(install, "_remove_legacy_launchers", return_value=[]),
+            _patch_platform_uninstalls(install),
+        ):
+            result = install.uninstall_all(pi=True)
+        mock_un.assert_called_once()
+        assert "pi: extension" in result
+
+    def test_install_all_pi_fail_soft(self) -> None:
+        from token_goat import install
+
+        with (
+            patch.object(bridges, "install_pi_plugin", side_effect=RuntimeError("disk full")),
+            patch.object(install, "patch_settings_json", return_value=(True, "ok")),
+            patch.object(install, "patch_claude_md", return_value="ok"),
+            patch.object(install, "write_skill", return_value="ok"),
+            patch.object(install, "_remove_legacy_launchers", return_value=[]),
+            patch("token_goat.worker.ensure_running", return_value=0),
+            _patch_platform_installs(install),
+        ):
+            result = install.install_all(install_pi=True)
+        assert "FAIL" in result["pi: extension"]
 
     def test_install_all_opencode_called_when_flag_set(self) -> None:
         from token_goat import install

--- a/tests/test_install_detect.py
+++ b/tests/test_install_detect.py
@@ -137,6 +137,7 @@ def test_detect_installed_harnesses_returns_dict():
         "gemini",
         "opencode",
         "openclaw",
+        "pi",
         "cline",
         "windsurf",
         "copilot-cli",


### PR DESCRIPTION
Hi! 👋 Thanks for building token-goat. I tried it and it was really fascinating, so I wanted to take a shot at wiring it up for [pi](https://github.com/earendil-works/pi-mono) (pi-coding-agent) — the README mentions new agent CLI integrations are welcome. This is my attempt at it. I'm still fairly new to this, so I'm very open to feedback or changes, and no worries if it's not a direction you want.

## What it does

Adds a `--pi` install target, following the same pattern as the existing opencode/openclaw bridges — the Python engine is untouched. It's a thin TypeScript extension that forwards pi's events to the existing `token-goat hook <event>` subprocess protocol.

`token-goat install --pi` drops an extension at `~/.pi/agent/extensions/token-goat.ts`. It subscribes to pi's `session_start`, `tool_call`, `tool_result`, `session_before_compact`, and `session_compact` events.

Working:
- bash output compression (command rewritten in `tool_call`)
- re-read denial (`tool_call` returns `{ block, reason }`)
- image shrinking + surgical-read redirects (args rewritten in place)
- post-edit indexing + output caching (`tool_result`)
- compaction manifest (captured at `session_before_compact`, re-injected after `session_compact` — pi replaces the summary instead of appending, so it can't push extra context the way opencode's compaction hook does)

Not included: skill-overhead preservation. As far as I can tell pi has no Skill tool — skills are template expansions there — so that part doesn't really apply.

## Changes
- `bridges.py`: `PI_EXTENSION_TS` + `pi_extensions_dir` / `install_pi_plugin` / `uninstall_pi_plugin` / `_check_pi_plugin` (with a `target_dir` arg for project-local installs)
- `install.py` + `cli.py`: wire `pi` into `--target`, the `--pi` flag, and `plan_install` / `install_all` / `uninstall_all` / `check_status` / `detect_installed_harnesses`
- tests: pi bridge tests in `test_bridges.py` (TS smoke checks, hook-event registry alignment, install/uninstall/check) and the harness-key set in `test_install_detect.py`
- README + CHANGELOG (`[Unreleased]`) notes

## Testing
- The bridge and install suites pass locally (`test_bridges.py`, `test_install*.py`).
- One honest caveat: I couldn't run the *full* suite on my machine (macOS x86_64 — `onnxruntime` has no wheel for that platform), so CI is the real check there. Flagging it in case something I can't see locally needs a fix.

Thanks again for the project!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
