### PR TITLE
Pi-native TypeScript port – just a heads-up!

### DIFF
--- a/TS-PORT-NOTE.md
+++ b/TS-PORT-NOTE.md
@@ -1,0 +1,17 @@
+# TypeScript Port of token-goat → [pi-token-goat](https://github.com/eSaadster/pi-token-goat)
+
+Just a quick heads-up — I made a TypeScript/Node.js port of token-goat!
+
+👉 **https://github.com/eSaadster/pi-token-goat**
+
+**Why?** Two reasons:
+
+1. I use [pi](https://github.com/earendil-works/pi-mono), which is a TypeScript-native coding agent. I wanted token-goat to run in-process instead of forking Python on every hook call, so the whole thing got ported as a native TS extension.
+
+2. I wanted to see if I could take a real, honest-to-goodness tool and move it into a language / framework I'm still learning. I'm a Python/bash person by trade and TypeScript + Node was way outside my comfort zone. It was... humbling. And I loved it.
+
+It is a line-by-line port — all 80+ CLI commands, 130+ bash filters, code/session/skill compaction, image shrinking, read optimization, the whole hook system. ~280 tests so far. Same TOML config, same env vars, same defaults. Just different plumbing: `commander` instead of `typer`, `better-sqlite3` instead of `sqlite3`, native `async/await` instead of `asyncio`, and a pi extension that hooks straight into the agent's event loop instead of routing through a subprocess.
+
+Not trying to replace anything — this is my "learn a new stack" project that accidentally turned into something useful. Figured I'd drop a note in case it ever helps someone else running token-goat in a JS-heavy stack.
+
+— [eSaadster](https://github.com/eSaadster)


### PR DESCRIPTION
Hey! 👋

I forked token-goat into my own repo (`pi-token-goat`) and have been working on a **TypeScript/Node.js port** over the past week. Wanted to share what I did in case it is interesting.

**Two reasons I did this:**

1. **I use pi (a TypeScript-native coding agent).** pi is all Node.js under the hood, so every time token-goat needed to fire I was forking a Python subprocess. I figured embedding the whole thing directly into the JS runtime would be snappier — and it gave me an excuse to finally build something non-trivial in TypeScript.

2. **I wanted to see if I could take a substantial real-world tool and port it to a language / framework I am still learning.** I am really more of a Python + bash person by trade, and TypeScript + Node was outside my comfort zone. This started as "how hard could it be?" and turned into a couple weeks of reading source, chasing edge cases, and figuring out how to map things like `typer` → `commander`, `asyncio` → `async/await`, and `pytest` → `vitest`. It was humbling and I learned a ton.

**What works:** All 80+ CLI commands, bash output compression (130+ filters), code/session/skill compaction, image shrinking, read optimization, the hook system — all ported line-by-line. ~280 tests so far (nowhere near your coverage, but it is a start).

**What is different:** It runs as a single `esbuild` bundle, the pi integration is a native TS extension instead of a subprocess hop, and the config uses `smol-toml` / `better-sqlite3` instead of Python stdlib equivalents. Same `TOKEN_GOAT_*` env vars, same TOML config shape, same defaults.

This is absolutely not meant to replace or compete with the Python original — just a personal port for my own stack and a massive learning experience. I figured I would open a PR so it is on your radar in case anyone ever asks about a Node/TS path, and so I can say I finally sent a PR to something real 😅

Thanks for building token-goat — it has saved me a ridiculous amount of tokens.