### PR TITLE
Fix runSymbol empty-body regression for Salesforce metadata, add extractor dispatch table

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1281,42 +1281,46 @@ function sectionsToHeadingSymbols(
   }))
 }
 
+type SymbolExtractor = (content: string, filePath: string) => SymbolEntry[]
+
+// One entry per non-tree-sitter Language. Adding a new adapter is one map entry rather than
+// a new `if` branch; html/liquid keep their extra sectionsToHeadingSymbols composition inline.
+const NO_TREE_SITTER_EXTRACTORS: Partial<Record<Language, SymbolExtractor>> = {
+  markdown: extractMarkdownSymbols,
+  json: extractJsonSymbols,
+  yaml: extractYamlSymbols,
+  toml: extractTomlSymbols,
+  css: extractCssSymbols,
+  dockerfile: extractDockerfileSymbols,
+  csharp: (content, filePath) => extractCsharp(content, filePath).symbols,
+  php: (content, filePath) => extractPhp(content, filePath).symbols,
+  html: (content, filePath) => {
+    const r = extractHtml(content, filePath)
+    return [...r.symbols, ...sectionsToHeadingSymbols(r.sections, filePath)]
+  },
+  liquid: (content, filePath) => {
+    const r = extractLiquid(content, filePath)
+    return [...r.symbols, ...sectionsToHeadingSymbols(r.sections, filePath)]
+  },
+  kotlin: (content, filePath) => extractKotlin(content, filePath).symbols,
+  graphql: (content, filePath) => extractGraphql(content, filePath).symbols,
+  sql: extractSql,
+  ini: extractIni,
+  makefile: extractMakefile,
+  proto: (content, filePath) => extractProto(content, filePath).symbols,
+  powershell: (content, filePath) => extractPowershell(content, filePath).symbols,
+  apex: (content, filePath) => extractApex(content, filePath).symbols,
+  salesforce_metadata: (content, filePath) => extractSalesforceMetadata(content, filePath).symbols,
+  env_file: extractEnv,
+}
+
 function extractSymbolsNoTreeSitter(
   content: string,
   filePath: string,
   language: Language,
 ): SymbolEntry[] {
-  if (language === 'markdown') return extractMarkdownSymbols(content, filePath)
-  if (language === 'json') return extractJsonSymbols(content, filePath)
-  if (language === 'yaml') return extractYamlSymbols(content, filePath)
-  if (language === 'toml') return extractTomlSymbols(content, filePath)
-  if (language === 'css') return extractCssSymbols(content, filePath)
-  if (language === 'dockerfile') return extractDockerfileSymbols(content, filePath)
-
-  // New language adapters from ./languages/
-  if (language === 'csharp') return extractCsharp(content, filePath).symbols
-  if (language === 'php') return extractPhp(content, filePath).symbols
-  if (language === 'html') {
-    const r = extractHtml(content, filePath)
-    return [...r.symbols, ...sectionsToHeadingSymbols(r.sections, filePath)]
-  }
-  if (language === 'liquid') {
-    const r = extractLiquid(content, filePath)
-    return [...r.symbols, ...sectionsToHeadingSymbols(r.sections, filePath)]
-  }
-  if (language === 'kotlin') return extractKotlin(content, filePath).symbols
-  if (language === 'graphql') return extractGraphql(content, filePath).symbols
-  if (language === 'sql') return extractSql(content, filePath)
-  if (language === 'ini') return extractIni(content, filePath)
-  if (language === 'makefile') return extractMakefile(content, filePath)
-  if (language === 'proto') return extractProto(content, filePath).symbols
-  if (language === 'powershell') return extractPowershell(content, filePath).symbols
-  if (language === 'apex') return extractApex(content, filePath).symbols
-  if (language === 'salesforce_metadata') return extractSalesforceMetadata(content, filePath).symbols
-  if (language === 'env_file') return extractEnv(content, filePath)
-
   if (language === 'unknown') return []
-  return extractWithRegex(content, filePath)
+  return (NO_TREE_SITTER_EXTRACTORS[language] ?? extractWithRegex)(content, filePath)
 }
 
 /**

--- a/src/read_commands.ts
+++ b/src/read_commands.ts
@@ -151,7 +151,17 @@ export function runSymbol(opts: SymbolOptions): { text: string; code: number } {
   // Header + short body preview per match (mirrors the richer surface that the native CLI handler used before the two read surfaces were consolidated).
   const blocks = results.map((sym) => {
     const header = `# ${sym.name} (${sym.kind}) — ${sym.filePath}:${sym.lineStart}-${sym.lineEnd}`
-    const preview = sym.body.split(/\r?\n/).slice(0, 5).join('\n')
+    let body = sym.body
+    if (body === '') {
+      const source = readFileText(sym.filePath)
+      if (source !== null) {
+        body = source
+          .split(/\r?\n/)
+          .slice(Math.max(0, sym.lineStart - 1), sym.lineEnd)
+          .join('\n')
+      }
+    }
+    const preview = body.split(/\r?\n/).slice(0, 5).join('\n')
     return preview.trim() !== '' ? `${header}\n${preview}` : header
   })
   return { text: blocks.join('\n\n'), code: 0 }

--- a/tests/read_commands.test.ts
+++ b/tests/read_commands.test.ts
@@ -155,6 +155,27 @@ describe('read_commands', () => {
       expect(Array.isArray(parsed)).toBe(true)
     })
 
+    it('reconstructs an empty indexed body from its source span for the preview', () => {
+      const filePath = path.join(tempDir, 'Example.profile-meta.xml')
+      fs.writeFileSync(filePath, '<Profile>\n  <label>Example</label>\n</Profile>\n')
+      const sym: MockSymbol = {
+        name: 'Example',
+        kind: 'sf_profile',
+        filePath,
+        lineStart: 1,
+        lineEnd: 3,
+        body: '',
+        docstring: '',
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockQuerySymbols.mockReturnValue([sym as any])
+
+      const { text: stdout } = runSymbol({ name: 'Example' })
+
+      expect(stdout).toContain('<Profile>')
+      expect(stdout).toContain('<label>Example</label>')
+    })
+
     it('resolves the filePath filter to the index key before querying', () => {
       mockQuerySymbols.mockReturnValue([])
       runSymbol({ name: 'x', file: 'src/bar.ts' })


### PR DESCRIPTION
Follow-up to #9.

## What's fixed

`wholeFileSpan()` in `salesforce_metadata.ts` stores `body: ''` for every metadata kind (CustomObject, CustomField, ValidationRule, PermissionSet, Profile, CustomMetadata, and the generic fallback), not just profiles. #9 added a disk-reconstruction fallback to `runRead` for this, but `runSymbol` (`token-goat symbol NAME`) still read `sym.body` directly with no fallback, so it showed an empty preview for every Salesforce metadata symbol. This mirrors the same disk-reconstruction fallback into `runSymbol`, with a test.

## What's refactored

`extractSymbolsNoTreeSitter` in `parser.ts` was a 19-branch `if` chain dispatching `Language` to its extractor function, growing by one branch per language added. Replaced with a `Partial<Record<Language, extractor>>` lookup table. `html`/`liquid` keep their extra `sectionsToHeadingSymbols` composition as inline lambda values, unchanged behavior.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test` (4747 passed, 4 skipped)
- Built `dist/token-goat.mjs` and dogfooded against real fixtures: `token-goat symbol` and `token-goat read` both correctly reconstruct the body from disk for a `.profile-meta.xml` symbol; `token-goat symbol` still resolves an Apex method through the new dispatch table.
