### PR TITLE
test(apex): cover safe-navigation symbol indexing

### DIFF
--- a/tests/fixtures/salesforce-dx/force-app/main/default/classes/SafeNavigationService.cls
+++ b/tests/fixtures/salesforce-dx/force-app/main/default/classes/SafeNavigationService.cls
@@ -1,0 +1,30 @@
+public class SafeNavigationService {
+  public Boolean beforeNavigation(Account account) {
+    return account != null;
+  }
+
+  // Don't let comment punctuation hide this method or anything after it.
+  private Boolean hasDirectName(Account account) {
+    return String.isBlank(account?.Name);
+  }
+
+  private Boolean hasRelatedName(Account account) {
+    return String.isBlank(account?.Parent?.Name);
+  }
+
+  private void logRelatedName(Account account) {
+    System.debug(account?.Parent?.Name);
+  }
+
+  public void finishWork() {
+    System.debug('finished');
+  }
+
+  public void afterFinish() {
+    System.debug('after');
+  }
+
+  public void finalMethod() {
+    System.debug('complete');
+  }
+}

--- a/tests/fixtures/salesforce-dx/force-app/main/default/classes/SafeNavigationService.cls-meta.xml
+++ b/tests/fixtures/salesforce-dx/force-app/main/default/classes/SafeNavigationService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>65.0</apiVersion>
+  <status>Active</status>
+</ApexClass>

--- a/tests/salesforce_worker_e2e.test.ts
+++ b/tests/salesforce_worker_e2e.test.ts
@@ -116,6 +116,21 @@ describe('Salesforce DX worker default path', () => {
       expect(querySymbols({ name: 'loadAccount' }, dbPath)[0]).toMatchObject({
         kind: 'apex_method',
       })
+      // Safe-navigation is covered on the real worker path, including methods after it. The
+      // fixture also contains an apostrophe in a preceding line comment, the historical masker
+      // failure that could blank the remainder of an otherwise valid Apex file.
+      for (const name of [
+        'hasDirectName',
+        'hasRelatedName',
+        'logRelatedName',
+        'finishWork',
+        'afterFinish',
+        'finalMethod',
+      ]) {
+        expect(querySymbols({ name }, dbPath)[0], name).toMatchObject({
+          kind: 'apex_method',
+        })
+      }
 
       // The LWC bundle and its public API are addressable across JS/template/metadata files.
       expect(querySymbols({ name: 'accountCard' }, dbPath).length).toBeGreaterThan(0)
@@ -156,6 +171,37 @@ describe('Salesforce DX built bundle smoke', () => {
     const indexed = runBundle(repo, dataBase, ['index', repo])
     expect(indexed.status, indexed.stderr).toBe(0)
     expect(indexed.stdout).toMatch(/Indexed \d+ files/)
+
+    // Exercise every user-visible read seam against the shipped bundle, not only the adapter.
+    const apexFile = 'force-app/main/default/classes/SafeNavigationService.cls'
+    const outline = runBundle(repo, dataBase, ['outline', apexFile])
+    expect(outline.status, outline.stderr).toBe(0)
+    expect(outline.stdout).toContain('SafeNavigationService')
+    for (const name of [
+      'hasDirectName',
+      'hasRelatedName',
+      'logRelatedName',
+      'finishWork',
+      'afterFinish',
+      'finalMethod',
+    ]) {
+      expect(outline.stdout, name).toContain(name)
+    }
+
+    const safeNavigationSymbol = runBundle(repo, dataBase, ['symbol', 'hasRelatedName'])
+    expect(safeNavigationSymbol.status, safeNavigationSymbol.stderr).toBe(0)
+    expect(safeNavigationSymbol.stdout).toContain('account?.Parent?.Name')
+
+    const methodAfterSafeNavigation = runBundle(repo, dataBase, [
+      'read',
+      `${apexFile}::finishWork`,
+    ])
+    expect(methodAfterSafeNavigation.status, methodAfterSafeNavigation.stderr).toBe(0)
+    expect(methodAfterSafeNavigation.stdout).toContain('public void finishWork()')
+
+    const fullClass = runBundle(repo, dataBase, ['read', `${apexFile}::SafeNavigationService`])
+    expect(fullClass.status, fullClass.stderr).toBe(0)
+    expect(fullClass.stdout).toContain('public void finalMethod()')
 
     const symbol = runBundle(repo, dataBase, ['symbol', 'accountCard'])
     expect(symbol.status, symbol.stderr).toBe(0)


### PR DESCRIPTION
## Summary

- add a fully synthetic Apex fixture covering `object?.field`, chained `object?.relation?.field`, safe-navigation in a return expression, and safe-navigation in a call argument
- verify several methods after the safe-navigation methods remain indexed
- exercise the real worker default path and the built bundle through `index`, `outline`, `symbol`, and `read`
- assert that reading the class reaches its final method, guarding against partial-file truncation

## Root cause and context

After rebasing onto the latest upstream `main`, safe-navigation itself already indexes correctly. The upstream parser also contains the fix for the matching partial-index failure class: context-blind Apex string masking could treat an apostrophe in a `//` comment as an opening quote and blank the remainder of the file, leaving full chunks but dropping later symbols. The synthetic fixture deliberately places such a comment immediately before the safe-navigation methods, so the shipped worker and CLI now protect the complete observed boundary without using private source material.

## Validation

- `npm run build` — passed
- `npm run lint` — passed
- `npm run typecheck` — passed under Node 24 after installing current optional dependencies
- `npm run test:guards` — 15/15 passed
- focused Apex + worker/bundle tests — 21/21 passed
- manual built-bundle smoke: `index`, `outline`, `symbol`, and `read` all passed on the synthetic fixture; outline returned the complete 8-symbol class through `finalMethod`

The full local suite is currently blocked by two unrelated upstream macOS config-path assertions. The command matrix passes 107/111 commands; its four local failures are the XLSX fixture commands because npm did not retain the optional `exceljs` package. All Apex and shipped-bundle coverage added here passes.

## Privacy

The fixture, test names, paths, and assertions are synthetic and contain no private repository identifiers or source fragments.
