### PR TITLE
feat(bridges): add Kimi Code CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Token-Goat are documented in this file. Format follows Keep a Changelog. Token-Goat follows Semantic Versioning starting at 1.0.
 
+## [Unreleased]
+
+### Added
+
+- **Kimi Code support.** `token-goat install --kimi` wires token-goat into Moonshot AI's Kimi Code CLI: `[[hooks]]` entries in `~/.kimi-code/config.toml` for `PreToolUse`, `PostToolUse`, `PreCompact`, `UserPromptSubmit`, `SubagentStop`, and `SessionStart`, a routing block in `~/.kimi-code/AGENTS.md`, and a skill at `~/.kimi-code/skills/token-goat/SKILL.md`. Kimi Code sends the same snake_case payload Claude Code does, but it reads a different answer: only a top-level `message` and `hookSpecificOutput.permissionDecision`. Sending token-goat's own reply would have been read as "allow" every time, so the install writes a shim that translates it, and writes nothing at all for a no-op, because Kimi Code puts raw hook stdout into the model's context on `UserPromptSubmit`. Its read tool names its argument `path`, not `file_path`, so the payload is renamed on the way in as well. `Notification` and `Stop` are not wired: token-goat has no handler for them. Input and output rewriting are not wired either, because Kimi Code offers no channel for them. See [src/bridges/kimi_install.ts](src/bridges/kimi_install.ts) and [src/bridges/kimi.ts](src/bridges/kimi.ts), held by [tests/install_kimi.test.ts](tests/install_kimi.test.ts) and [tests/wire_format_kimi.test.ts](tests/wire_format_kimi.test.ts).
+
 ## [2.6.32] - 2026-08-18
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ permalink: /
 
 Token-Goat sits silently between your AI and your tools. Re-read a file? It gets a one-line hint and a narrow-slice suggestion instead of the full file again. Grab a screenshot? A 100 KB copy reaches the model instead of 10 MB. Run `pytest`, `npm install`, `docker build`, or `cargo`? The thousands of progress bars and passing-test names are stripped to the failures before the output even reaches the context window. Open a PDF, a large Markdown doc, or a CSV? The hook intercepts it — heading tree, page count, or column preview — so the model never pays for the full file. Run `gh run watch` or `next dev` a second time? Prior output is recalled rather than re-run. Compact a long session? It gets a clean structured manifest of edited files and key symbols so nothing important is forgotten. Sessions drop 40–90%+ in cost. You change nothing about how you work.
 
-Works with **Claude Code**, **Gemini CLI**, **Qwen Code**, **Codex CLI**, **Aider**, **Cursor**, **Cline**, **Windsurf**, **Copilot CLI**, **Grok CLI** (xAI Grok Build), and OpenCode, plus **pi** ([pi-coding-agent](https://github.com/earendil-works/pi-mono)).
+Works with **Claude Code**, **Gemini CLI**, **Qwen Code**, **Codex CLI**, **Aider**, **Cursor**, **Cline**, **Windsurf**, **Copilot CLI**, **Kimi Code**, **Grok CLI** (xAI Grok Build), and OpenCode, plus **pi** ([pi-coding-agent](https://github.com/earendil-works/pi-mono)).
 
 **Ask your AI to install it fully (give it this GitHub link), or install in one command:**
 
@@ -392,6 +392,14 @@ token-goat install --qwen
 ```
 
 This writes hook entries into `~/.qwen/settings.json`. Unlike Gemini CLI (its own ancestor, with a custom `BeforeTool`/`AfterTool`/`PreCompress` event/matcher scheme), Qwen Code's hooks system diverged and now mirrors Claude Code's own natively — `PreToolUse`/`PostToolUse`/`PreCompact`/`UserPromptSubmit`/`SubagentStop` event names and snake_case stdin JSON — so token-goat wires all five events with no wire-format translation needed. Qwen Code's own tool-name taxonomy is only partially documented, so token-goat uses a catch-all matcher per event rather than an incomplete per-tool list. Image shrinking, session hints, post-edit indexing, compact assist, and bash output compression all work. This bridge was built from QwenLM/qwen-code's published docs, not dogfooded against a live Qwen Code install — if hooks aren't firing, `token-goat doctor` and the settings.json contents are the first things to check. To remove: `token-goat uninstall --qwen`.
+
+### Kimi Code users
+
+```
+token-goat install --kimi
+```
+
+This writes `[[hooks]]` entries into `~/.kimi-code/config.toml` (or `$KIMI_CODE_HOME/config.toml`), covering Kimi Code's `PreToolUse`, `PostToolUse`, `PreCompact`, `UserPromptSubmit`, `SubagentStop`, and `SessionStart` events. Kimi Code sends a Claude-Code-shaped snake_case payload on stdin, but it reads a different response: only a top-level `message` and `hookSpecificOutput.permissionDecision` / `permissionDecisionReason`. So the install also writes a small shim at `~/.kimi-code/hooks/token-goat-shim.js` that translates token-goat's answer into that contract, turns a hint into `message`, and writes nothing at all for a no-op. Image shrinking, session hints, post-edit indexing, compact assist, and bash output compression all work. `Notification` and `Stop` are not wired, because token-goat has no handler for them. Input and output rewriting are not wired either: Kimi Code offers no channel to replace a tool's input or its result. This bridge was built from MoonshotAI/kimi-code's own source and docs, not dogfooded against a live Kimi Code install, so if hooks are not firing, `token-goat doctor` and the `config.toml` contents are the first things to check. To remove: `token-goat uninstall --kimi`.
 
 ### opencode users
 
@@ -936,6 +944,15 @@ Three things follow, and they are worth knowing before you decide. It never leav
 | Path | What |
 |------|------|
 | `~/.qwen/settings.json` | Hook entries under Qwen Code's `PreToolUse`, `PostToolUse`, `PreCompact`, `UserPromptSubmit`, and `SubagentStop` events (Claude-Code-native names and payload shape, not Gemini's), using a catch-all matcher per event. Existing hooks preserved; a timestamped `.bak` is written before any change. |
+
+**With `--kimi`** (Kimi Code integration)
+
+| Path | What |
+|------|------|
+| `~/.kimi-code/config.toml` | `[[hooks]]` entries for Kimi Code's `PreToolUse`, `PostToolUse`, `PreCompact`, `UserPromptSubmit`, `SubagentStop`, and `SessionStart` events. Each entry carries only `event` and `command`, the keys Kimi Code's strict schema accepts. Existing hooks and other config keys preserved; a timestamped `.bak` is written before any change. |
+| `~/.kimi-code/hooks/token-goat-shim.js` | The hook script those commands invoke. Rewrites a token-goat block into `hookSpecificOutput.permissionDecision` and a hint into a top-level `message`, and writes empty stdout for a no-op. Regenerated on every `install --kimi` run. |
+| `~/.kimi-code/AGENTS.md` | A delimited block (`<!-- token-goat-kimi-begin -->` ... `<!-- token-goat-kimi-end -->`) with the routing guidance, adapted for Kimi Code tool names. |
+| `~/.kimi-code/skills/token-goat/SKILL.md` | The same guidance as a Kimi Code skill. |
 
 **With `--opencode`** (opencode plugin)
 

--- a/src/bridges/index.ts
+++ b/src/bridges/index.ts
@@ -34,6 +34,20 @@ export {
   uninstallCopilotCli,
 } from './copilot_cli_install.js'
 export type { CopilotCliInstallResult, CopilotCliScopeOptions } from './copilot_cli_install.js'
+export { KIMI_HOOK_SCRIPT } from './kimi.js'
+export {
+  KimiConfigParseError,
+  KIMI_HOOK_EVENTS,
+  installKimi,
+  isKimiInstalled,
+  kimiAgentsPath,
+  kimiConfigPath,
+  kimiHome,
+  kimiHookScriptPath,
+  kimiSkillPath,
+  uninstallKimi,
+} from './kimi_install.js'
+export type { KimiInstallResult } from './kimi_install.js'
 export { GROK_HOOK_SCRIPT } from './grok.js'
 export {
   grokConfigPath,

--- a/src/bridges/kimi.ts
+++ b/src/bridges/kimi.ts
@@ -1,0 +1,193 @@
+/**
+ * Kimi Code CLI bridge (MoonshotAI/kimi-code).
+ *
+ * Kimi Code fires hooks the same way Claude Code does: a `command` string from
+ * its config file is spawned per event, the payload arrives as JSON on stdin
+ * with snake_case field names (`hook_event_name`, `session_id`, `cwd`,
+ * `tool_name`, `tool_input`), and the script answers on stdout. Verified
+ * against MoonshotAI/kimi-code's own source and docs, not guessed:
+ *
+ * - Payload keys and the camelCase->snake_case conversion:
+ *   `packages/agent-core-v2/src/app/externalHooksRunner/runner.ts`
+ *   (`toHookInputData` / `camelToSnake`, and the `hookEventName`/`sessionId`/
+ *   `cwd` base fields), plus `docs/en/customization/hooks.md`'s "Event Data
+ *   Format" section.
+ * - `tool_name` / `tool_input` for `PreToolUse`/`PostToolUse`:
+ *   `packages/agent-core-v2/src/agent/externalHooks/externalHooksService.ts`
+ *   (`runPreToolUse`, `notifyPostToolUse`).
+ *
+ * The response contract is where Kimi diverges from Claude Code, and it is the
+ * reason this bridge needs a translating shim rather than wiring `token-goat
+ * hook <event>` straight into the config the way the Qwen Code bridge does.
+ * Kimi's stdout parser is `structuredOutput()` in
+ * `packages/agent-core-v2/src/agent/externalHooks/runner.ts`, whose schema
+ * (`HookJsonOutputSchema`) reads exactly three fields: top-level `message`,
+ * `hookSpecificOutput.message`, and `hookSpecificOutput.permissionDecision` /
+ * `permissionDecisionReason`. So:
+ *
+ * - token-goat's deny shape, `{"decision":"block","reason":"..."}`
+ *   (`serializeOutput` in ../hook_registry.ts), means nothing to Kimi: it
+ *   would be parsed, found to have no `permissionDecision`, and allowed. The
+ *   shim rewrites it to `hookSpecificOutput.permissionDecision = "deny"` with
+ *   `permissionDecisionReason`, which `resultFromExitCode` turns into a real
+ *   block on exit 0.
+ * - token-goat's hint shapes, `hookSpecificOutput.additionalContext` and the
+ *   top-level `systemMessage`, are both ignored by Kimi's schema. The shim
+ *   maps either one onto the top-level `message` field Kimi does read.
+ * - A no-op `{}` is written as *empty* stdout, not as the literal `{}`. On
+ *   `UserPromptSubmit`, Kimi falls back to raw stdout when a structured
+ *   response carries no message (`userPromptHookMessage` in
+ *   `packages/agent-core-v2/src/agent/externalHooks/user-prompt.ts`), so
+ *   printing `{}` would inject the two characters `{}` into the model's
+ *   context on every prompt.
+ *
+ * Not translated, because Kimi has no equivalent: token-goat's `rewriteInput`
+ * (`updatedInput`) and `rewriteOutput` (`updatedToolOutput`). `runPreToolUse`
+ * returns only a block reason and `notifyPostToolUse` is fire-and-forget, so
+ * Kimi offers no channel to replace a tool's input or its result. Those
+ * responses degrade to a no-op here rather than being faked.
+ */
+
+/**
+ * Node source for the Kimi Code hook shim.
+ *
+ * Behavior mirrors the Codex shim (validate `eventName` against the closed set
+ * of known hook events, read stdin, call the in-process hook lib or fall back
+ * to spawning `token-goat hook <event>`), with two Kimi-specific differences:
+ *
+ * 1. It sets `TOKEN_GOAT_HARNESS_OVERRIDE=kimi` before dispatching. Kimi Code
+ *    publishes no ambient per-session environment variable that
+ *    `detectHarness()` (../bridges/registry.ts) could key off: its documented
+ *    variables (`KIMI_CODE_HOME`, `KIMI_DISABLE_TELEMETRY`, the `KIMI_MODEL_*`
+ *    family, and the provider credential names) are all user-set inputs, not
+ *    signals the CLI exports into every hook subprocess. Same workaround the
+ *    Copilot CLI and pi bridges use for the same reason.
+ * 2. It rewrites the response into Kimi's own wire contract (see this module's
+ *    docstring) instead of relaying it verbatim.
+ *
+ * `eventName` is validated against `VALID_HOOK_EVENTS` before it is ever
+ * concatenated into a shell command string, so a hostile argv cannot reach the
+ * shell parser. On any error the shim writes nothing and exits 0, which Kimi
+ * treats as "allow" (its fail-open design, `docs/en/customization/hooks.md`).
+ */
+export const KIMI_HOOK_SCRIPT = `#!/usr/bin/env node
+// token-goat Kimi Code hook shim. Forwards the hook payload to \`token-goat hook <event>\`, then rewrites the response into Kimi's own contract: permissionDecision "deny" for a block, top-level "message" for a hint, empty stdout for a no-op.
+'use strict'
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+
+// Keep in sync with HOOK_EVENTS in src/types.ts. eventName is validated against this closed
+// set before being concatenated into a shell command string, so a hostile argv (e.g.
+// 'pre_tool_use & calc.exe') can never reach the shell parser.
+const VALID_HOOK_EVENTS = new Set([
+  'pre_tool_use',
+  'post_tool_use',
+  'notification',
+  'stop',
+  'pre_compact',
+  'user_prompt_submit',
+  'subagent_stop',
+  'session_start',
+])
+
+// Kimi Code publishes no ambient per-session env var identifying its own hook
+// subprocesses, so the harness identity has to be injected here for
+// detectHarness() (src/bridges/registry.ts) to resolve 'kimi'.
+process.env.TOKEN_GOAT_HARNESS_OVERRIDE = 'kimi'
+
+// Pull the hint text out of a token-goat response: hookSpecificOutput.additionalContext
+// (most events) or the top-level systemMessage (notification/pre_compact, which Claude
+// Code rejects additionalContext on). Kimi reads neither, so both fold into its 'message'.
+function hintText(parsed) {
+  if (!parsed || typeof parsed !== 'object') return ''
+  const hso = parsed.hookSpecificOutput
+  if (hso && typeof hso === 'object' && typeof hso.additionalContext === 'string') return hso.additionalContext
+  if (typeof parsed.systemMessage === 'string') return parsed.systemMessage
+  return ''
+}
+
+// Translate a token-goat (Claude Code shaped) response into Kimi's contract.
+// Returns '' for anything Kimi cannot act on, which the caller writes as empty
+// stdout rather than '{}' -- see this module's docstring for why that matters
+// on UserPromptSubmit.
+function toKimi(parsed) {
+  if (!parsed || typeof parsed !== 'object') return ''
+  if (parsed.decision === 'block' && typeof parsed.reason === 'string' && parsed.reason) {
+    return JSON.stringify({
+      message: parsed.reason,
+      hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: parsed.reason },
+    })
+  }
+  const hint = hintText(parsed)
+  if (hint) return JSON.stringify({ message: hint })
+  return ''
+}
+
+// Attempts the in-process hook call: import()s dist/token-goat-hook.mjs (a sibling of
+// the baked token-goat entry path, built with zero load-time side effects) and calls its
+// exported relayInProcess() directly, avoiding a second node process spawn entirely.
+// Returns undefined (triggering the spawnSync fallback below) when entryPath is absent,
+// the sibling file doesn't exist, or anything else goes wrong -- this must never throw.
+async function tryInProcess(entryPath, eventName, input) {
+  if (!entryPath) return undefined
+  try {
+    const hookLibPath = path.join(path.dirname(entryPath), 'token-goat-hook.mjs')
+    if (!require('node:fs').existsSync(hookLibPath)) return undefined
+    const mod = await import(pathToFileURL(hookLibPath).href)
+    const payload = JSON.parse(input)
+    return await mod.relayInProcess(eventName, payload)
+  } catch {
+    return undefined
+  }
+}
+
+async function main() {
+  const eventName = process.argv[2] || ''
+  if (!VALID_HOOK_EVENTS.has(eventName)) return
+  let input = ''
+  try {
+    input = require('node:fs').readFileSync(0, 'utf8')
+  } catch {
+    return
+  }
+  // process.argv[3], when present, is the absolute path to the token-goat CLI entry that ran
+  // 'token-goat install --kimi' (baked in by hookCommandFor in kimi_install.ts). Same three-step
+  // ladder as the Codex shim: in-process hook lib, then the baked entry via process.execPath,
+  // then a PATH-based shell:true invocation for an older cached hook config. The 3000ms
+  // timeout keeps both spawn fallbacks well inside Kimi's own 30s default hook timeout
+  // (docs/en/customization/hooks.md), so token-goat degrades to its own fail-open no-op.
+  const entryPath = process.argv[3]
+  let stdout = await tryInProcess(entryPath, eventName, input)
+  if (stdout === undefined) {
+    const res = entryPath
+      ? spawnSync(process.execPath, [entryPath, 'hook', eventName], {
+          input,
+          encoding: 'utf8',
+          timeout: 3000,
+          killSignal: 'SIGKILL',
+        })
+      : spawnSync('token-goat hook ' + eventName, {
+          input,
+          encoding: 'utf8',
+          shell: true,
+          timeout: 3000,
+          killSignal: 'SIGKILL',
+        })
+    if (res.status !== 0 || !res.stdout) return
+    stdout = res.stdout
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return
+  }
+  const out = toKimi(parsed)
+  if (out) process.stdout.write(out)
+}
+
+main().catch(() => {
+  // Fail open: write nothing, exit 0. Kimi treats a silent hook as "allow".
+})
+`

--- a/src/bridges/kimi_install.ts
+++ b/src/bridges/kimi_install.ts
@@ -1,0 +1,337 @@
+/**
+ * Kimi Code CLI (MoonshotAI/kimi-code) install / uninstall writer.
+ *
+ * `token-goat install --kimi` patches Kimi Code in addition to the base Claude
+ * Code install, exactly like `--codex`. This module only ever touches paths
+ * under Kimi's own data root, which is `$KIMI_CODE_HOME` when set and
+ * `~/.kimi-code` otherwise (`docs/en/configuration/data-locations.md`: "The
+ * default data root is `~/.kimi-code/`" and "If you need to move the data
+ * directory elsewhere ... set `KIMI_CODE_HOME`").
+ *
+ * Four artifacts are installed:
+ * - `<root>/hooks/token-goat-shim.js` -- {@link KIMI_HOOK_SCRIPT} written to
+ *   disk. `<root>/hooks/` is Kimi's own documented location for hook scripts
+ *   (`docs/en/customization/hooks.md` wires its worked example as
+ *   `node ~/.kimi-code/hooks/block-dangerous-bash.mjs`). The shim is invoked
+ *   with the absolute Node binary and a baked token-goat entry path rather
+ *   than a bare `node`/`token-goat` on PATH, same rationale as the Codex and
+ *   Copilot CLI bridges. Rewritten unconditionally on every install so an
+ *   upgraded token-goat's shim logic always reaches disk.
+ * - `<root>/config.toml` -- `[[hooks]]` entries, one per wired event. That is
+ *   Kimi's real hook config shape: an array of tables whose schema accepts
+ *   exactly `event`, `matcher`, `command`, and `timeout` and rejects anything
+ *   else (`HookDefSchema` is `.strict()` in
+ *   `packages/agent-core-v2/src/agent/externalHooks/configSection.ts`), which
+ *   is why nothing else is written into those tables. `matcher` is omitted so
+ *   each hook matches every target -- Kimi documents an omitted matcher as
+ *   "matches all", and token-goat's own handlers already filter by tool name.
+ *   Parsed and serialized with `smol-toml`, the same library `config.ts` uses
+ *   for token-goat's own config, so no TOML is hand-rolled. Every other key in
+ *   the file is preserved verbatim, and a timestamped `.bak` is written before
+ *   any in-place edit.
+ * - `<root>/AGENTS.md` -- the shared routing-guidance block between
+ *   `<!-- token-goat-kimi-begin -->` / `<!-- token-goat-kimi-end -->` markers.
+ *   Kimi reads global instructions from `$KIMI_CODE_HOME/AGENTS.md`
+ *   (`docs/en/customization/agents.md`: "Global Kimi-specific instructions can
+ *   live at `$KIMI_CODE_HOME/AGENTS.md`"). Content outside the markers is
+ *   always preserved.
+ * - `<root>/skills/token-goat/SKILL.md` -- the same gate body as Claude Code's
+ *   skill, under frontmatter Kimi actually parses. Kimi loads user skills from
+ *   `$KIMI_CODE_HOME/skills/` (`docs/en/customization/skills.md`), and a
+ *   directory-form `SKILL.md` **must** declare both `name` and `description`
+ *   or parsing fails -- so those two fields are written and nothing else.
+ *
+ * A corrupt-but-recoverable `config.toml` (exists but fails to parse) is never
+ * silently clobbered: {@link installKimi} throws {@link KimiConfigParseError}
+ * before any write, mirroring `codex_install.ts`'s strict-mode guard.
+ */
+
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { parse, stringify } from 'smol-toml'
+
+import { atomicWriteText, backupFile, ensureDirSync, extractErrorMessage, hookCommandFor, stripDelimitedBlock, upsertDelimitedBlock } from '../util.js'
+import { anchoredMarkerPattern } from '../install.js'
+import { KIMI_HOOK_SCRIPT } from './kimi.js'
+import { buildGuidanceBlock, buildGuidanceBody } from './guidance_block.js'
+import { loadConfig } from '../config.js'
+
+/**
+ * Kimi Code event names token-goat wires, mapped to the internal event arg.
+ *
+ * Every name here is a member of `HOOK_EVENT_TYPES` in
+ * `packages/agent-core-v2/src/agent/externalHooks/types.ts`. The remaining
+ * real Kimi events (`Notification`, `Stop`, `StopFailure`, `Interrupt`,
+ * `PostToolUseFailure`, `PermissionRequest`, `PermissionResult`,
+ * `UserPromptQueued`, `TurnStarted`, `TaskStarted`, `SubagentStart`,
+ * `SessionEnd`, `SessionHeartbeat`, `PostCompact`) are left unwired: none of
+ * them has a token-goat server-side handler to dispatch to, so wiring them
+ * would spawn a process per event to do nothing.
+ */
+const KIMI_EVENT_ARG: Readonly<Record<string, string>> = {
+  PreToolUse: 'pre_tool_use',
+  PostToolUse: 'post_tool_use',
+  PreCompact: 'pre_compact',
+  UserPromptSubmit: 'user_prompt_submit',
+  SubagentStop: 'subagent_stop',
+  SessionStart: 'session_start',
+}
+
+/** Wired Kimi event names, in the order they are written to `config.toml`. */
+export const KIMI_HOOK_EVENTS: readonly string[] = Object.keys(KIMI_EVENT_ARG)
+
+/**
+ * One `[[hooks]]` entry as Kimi's `config.toml` stores it. Only the four
+ * fields `HookDefSchema` accepts appear here; the schema is `.strict()`, so an
+ * extra key makes the whole config file fail to load.
+ */
+interface KimiHookEntry {
+  event: string
+  matcher?: string
+  command: string
+  timeout?: number
+}
+
+/** The `config.toml` shape read/written; unknown top-level keys are preserved verbatim. */
+interface KimiConfig {
+  hooks?: KimiHookEntry[]
+  [key: string]: unknown
+}
+
+/** Thrown by {@link installKimi} when `config.toml` exists but isn't parseable as TOML. */
+export class KimiConfigParseError extends Error {}
+
+/**
+ * Kimi's data root: `$KIMI_CODE_HOME` when set and non-blank, else
+ * `~/.kimi-code`. Resolved on every call rather than cached so tests (and a
+ * user switching roots between commands) see the current value.
+ */
+export function kimiHome(): string {
+  const override = process.env['KIMI_CODE_HOME']
+  if (override !== undefined && override.trim() !== '') return path.resolve(override)
+  return path.join(os.homedir(), '.kimi-code')
+}
+
+/** Absolute path to Kimi's `config.toml`. */
+export function kimiConfigPath(): string {
+  return path.join(kimiHome(), 'config.toml')
+}
+
+/** Absolute path to Kimi's global `AGENTS.md`. */
+export function kimiAgentsPath(): string {
+  return path.join(kimiHome(), 'AGENTS.md')
+}
+
+/** Absolute path the Kimi hook shim script is installed to. */
+export function kimiHookScriptPath(): string {
+  return path.join(kimiHome(), 'hooks', 'token-goat-shim.js')
+}
+
+/** Absolute path to the token-goat skill directory Kimi loads. */
+export function kimiSkillDir(): string {
+  return path.join(kimiHome(), 'skills', 'token-goat')
+}
+
+/** Absolute path to `<root>/skills/token-goat/SKILL.md`. */
+export function kimiSkillPath(): string {
+  return path.join(kimiSkillDir(), 'SKILL.md')
+}
+
+function readKimiConfig(p: string, opts: { strict?: boolean } = {}): KimiConfig {
+  let raw: string
+  try {
+    raw = fs.readFileSync(p, 'utf8')
+  } catch {
+    return {}
+  }
+  try {
+    return parse(raw) as KimiConfig
+  } catch (e) {
+    if (opts.strict === true) {
+      throw new KimiConfigParseError(
+        `Kimi Code config file '${p}' exists but contains invalid TOML. Fix or back up the file before running install. (${extractErrorMessage(e)})`,
+      )
+    }
+    return {}
+  }
+}
+
+/** Marker substring identifying a token-goat-authored Kimi hook command. */
+const KIMI_COMMAND_MARKER = 'token-goat'
+const KIMI_MARKER_PATTERN = anchoredMarkerPattern(KIMI_COMMAND_MARKER)
+
+/** True when `command` is a token-goat-authored Kimi hook invocation, anchored so an unrelated command that merely contains the word cannot false-positive. */
+function isKimiTokenGoatCommand(command: unknown): boolean {
+  return typeof command === 'string' && KIMI_MARKER_PATTERN.test(command)
+}
+
+const AGENTS_BEGIN = '<!-- token-goat-kimi-begin -->'
+const AGENTS_END = '<!-- token-goat-kimi-end -->'
+
+/** Routing-guidance block, adapted for Kimi Code's own tool names (see `docs/en/reference/tools.md` in MoonshotAI/kimi-code). */
+function buildKimiAgentsBlock(): string {
+  return buildGuidanceBlock({
+    beginMarker: AGENTS_BEGIN,
+    endMarker: AGENTS_END,
+    fallbackToolClause:
+      "Kimi Code's native `Read`, `Grep`, `Glob`, and `ReadMediaFile` tools (shell commands like `cat`/`type` run inside `Bash`)",
+    gdrive: loadConfig().gdrive.enabled,
+  })
+}
+
+function writeKimiAgentsBlock(p: string): boolean {
+  return upsertDelimitedBlock(p, AGENTS_BEGIN, AGENTS_END, buildKimiAgentsBlock())
+}
+
+function stripKimiAgentsBlock(p: string): boolean {
+  return stripDelimitedBlock(p, AGENTS_BEGIN, AGENTS_END)
+}
+
+/**
+ * The SKILL.md Kimi loads. Only `name` and `description` are declared: those
+ * two are required for a directory-form skill, and every other frontmatter
+ * field Kimi documents (`type`, `whenToUse`, `disableModelInvocation`,
+ * `arguments`) would change invocation semantics token-goat does not want.
+ * Notably there is no `allowed-tools` key in Kimi's schema, so none is written.
+ */
+function kimiSkillContent(): string {
+  const gdrive = loadConfig().gdrive.enabled
+  const frontmatter = [
+    '---',
+    'name: token-goat',
+    `description: Use before reading whole files or grepping wide. token-goat commands (symbol, read, section, semantic, outline, skeleton, map, refs, changed, config-get, bash-output, web-output${gdrive ? ', gdrive-sections' : ''}) return narrow slices of code and docs at a fraction of the token cost.`,
+    '---',
+  ].join('\n')
+  const body = buildGuidanceBody("Kimi Code's own Read, Grep, and Glob preference rules", { gdrive })
+  return `${frontmatter}\n\n${body}\n`
+}
+
+function writeKimiSkill(): boolean {
+  const p = kimiSkillPath()
+  const content = kimiSkillContent()
+  let existing: string | null = null
+  try {
+    existing = fs.readFileSync(p, 'utf8')
+  } catch {
+    // Absent; falls through to the write below.
+  }
+  if (existing === content) return false
+  ensureDirSync(kimiSkillDir())
+  atomicWriteText(p, content)
+  return true
+}
+
+/** Outcome of an {@link installKimi} call. */
+export interface KimiInstallResult {
+  readonly configPath: string
+  readonly agentsPath: string
+  readonly hookScriptPath: string
+  readonly skillPath: string
+  /** True when every artifact was already present and up to date (no write needed). */
+  readonly alreadyInstalled: boolean
+}
+
+/** Install the Kimi Code CLI integration. */
+export function installKimi(): KimiInstallResult {
+  const configPath = kimiConfigPath()
+  const agentsPath = kimiAgentsPath()
+  const scriptPath = kimiHookScriptPath()
+
+  ensureDirSync(path.dirname(scriptPath))
+  atomicWriteText(scriptPath, KIMI_HOOK_SCRIPT)
+
+  // strict: true -- a config.toml that exists but fails to parse must abort before any write, not silently proceed as if it were empty and get clobbered below.
+  const config = readKimiConfig(configPath, { strict: true })
+  const existing = Array.isArray(config.hooks) ? config.hooks : []
+
+  const desired: KimiHookEntry[] = KIMI_HOOK_EVENTS.map((event) => ({
+    event,
+    command: hookCommandFor(scriptPath, KIMI_EVENT_ARG[event] ?? ''),
+  }))
+
+  // Everything token-goat did not write is preserved as-is; our own entries are
+  // rebuilt from scratch so a re-install upgrades a stale baked path in place
+  // instead of leaving a dead duplicate next to the current one.
+  const foreign = existing.filter((h) => !isKimiTokenGoatCommand(h?.command))
+  const ours = existing.filter((h) => isKimiTokenGoatCommand(h?.command))
+  const hooksChanged = JSON.stringify(ours) !== JSON.stringify(desired)
+
+  const agentsChanged = writeKimiAgentsBlock(agentsPath)
+  const skillChanged = writeKimiSkill()
+
+  if (hooksChanged) {
+    config.hooks = [...foreign, ...desired]
+    ensureDirSync(path.dirname(configPath))
+    backupFile(configPath)
+    atomicWriteText(configPath, stringify(config as Record<string, unknown>))
+  }
+
+  return {
+    configPath,
+    agentsPath,
+    hookScriptPath: scriptPath,
+    skillPath: kimiSkillPath(),
+    alreadyInstalled: !hooksChanged && !agentsChanged && !skillChanged,
+  }
+}
+
+/**
+ * Remove the Kimi Code integration: strips only token-goat's own `[[hooks]]`
+ * entries, the delimited AGENTS.md block, the skill directory, and the shim
+ * script. Returns true when anything was actually removed.
+ */
+export function uninstallKimi(): boolean {
+  const configPath = kimiConfigPath()
+  const config = readKimiConfig(configPath)
+  let removed = false
+
+  if (Array.isArray(config.hooks)) {
+    const kept = config.hooks.filter((h) => !isKimiTokenGoatCommand(h?.command))
+    if (kept.length !== config.hooks.length) {
+      if (kept.length === 0) {
+        delete config.hooks
+      } else {
+        config.hooks = kept
+      }
+      backupFile(configPath)
+      atomicWriteText(configPath, stringify(config as Record<string, unknown>))
+      removed = true
+    }
+  }
+
+  if (stripKimiAgentsBlock(kimiAgentsPath())) removed = true
+
+  try {
+    if (fs.existsSync(kimiSkillDir())) {
+      fs.rmSync(kimiSkillDir(), { recursive: true, force: true })
+      removed = true
+    }
+  } catch {
+    // best-effort: a locked skill directory must not fail the whole uninstall
+  }
+
+  try {
+    if (fs.existsSync(kimiHookScriptPath())) {
+      fs.rmSync(kimiHookScriptPath(), { force: true })
+      removed = true
+    }
+  } catch {
+    // best-effort, same rationale as the skill directory above
+  }
+
+  return removed
+}
+
+/** Is the Kimi Code integration currently present and up to date? */
+export function isKimiInstalled(): boolean {
+  const config = readKimiConfig(kimiConfigPath())
+  if (!Array.isArray(config.hooks)) return false
+  const scriptPath = kimiHookScriptPath()
+  for (const event of KIMI_HOOK_EVENTS) {
+    const expected = hookCommandFor(scriptPath, KIMI_EVENT_ARG[event] ?? '')
+    if (!config.hooks.some((h) => h?.event === event && h?.command === expected)) return false
+  }
+  return true
+}

--- a/src/bridges/registry.ts
+++ b/src/bridges/registry.ts
@@ -34,6 +34,7 @@ export const KNOWN_HARNESS_NAMES = new Set<string>([
   'copilot_cli',
   'grok',
   'qwen',
+  'kimi',
   'generic',
 ])
 
@@ -73,6 +74,13 @@ export const KNOWN_HARNESS_NAMES = new Set<string>([
  * `TOKEN_GOAT_HARNESS_OVERRIDE=copilot_cli` itself before invoking `token-goat
  * hook`, the same workaround `pi` uses for the same reason (see PI_EXTENSION_SCRIPT
  * in src/bridges/pi.ts).
+ *
+ * `kimi` (Kimi Code CLI) has no branch here either, for the same reason: every
+ * environment variable Kimi documents (`KIMI_CODE_HOME`,
+ * `KIMI_DISABLE_TELEMETRY`, the `KIMI_MODEL_*` family, and the provider
+ * credential names) is a user-set input rather than a signal the CLI exports
+ * into each hook subprocess. Its shim (KIMI_HOOK_SCRIPT in src/bridges/kimi.ts)
+ * sets `TOKEN_GOAT_HARNESS_OVERRIDE=kimi` itself.
  */
 export function detectHarness(): HarnessName {
   const env = process.env

--- a/src/bridges/types.ts
+++ b/src/bridges/types.ts
@@ -25,6 +25,7 @@ export type HarnessName =
   | 'copilot_cli'
   | 'grok'
   | 'qwen'
+  | 'kimi'
   | 'generic'
 
 /** Static description of how one harness's hooks are wired. */

--- a/src/bridges_status.ts
+++ b/src/bridges_status.ts
@@ -152,6 +152,13 @@ export const BRIDGE_CAPABILITY_MATRIX: readonly BridgeCapabilityRow[] = [
     ],
   },
   {
+    harness: 'kimi',
+    label: 'Kimi Code CLI',
+    sourceFile: 'src/bridges/kimi_install.ts (KIMI_EVENT_ARG), src/bridges/kimi.ts (KIMI_HOOK_SCRIPT)',
+    implemented: new Set(['pre_tool_use', 'post_tool_use', 'pre_compact', 'user_prompt_submit', 'subagent_stop', 'session_start']),
+    reasons: [{ events: ['notification', 'stop'], reason: NO_SERVER_HANDLER_REASON }],
+  },
+  {
     harness: 'opencode',
     label: 'opencode',
     sourceFile: 'src/bridges/opencode.ts',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ import type { HookScope } from './install.js'
 import { installCodex, isCodexInstalled, uninstallCodex } from './bridges/codex_install.js'
 import { installGemini, isGeminiInstalled, uninstallGemini } from './bridges/gemini_install.js'
 import { installQwen, isQwenInstalled, uninstallQwen } from './bridges/qwen_install.js'
+import { installKimi, isKimiInstalled, uninstallKimi } from './bridges/kimi_install.js'
 import { installPi, isPiInstalled, uninstallPi } from './bridges/pi_install.js'
 import { installOpencode, isOpencodeInstalled, uninstallOpencode } from './bridges/opencode_install.js'
 import { installOpenclaw, isOpenclawInstalled, uninstallOpenclaw } from './bridges/openclaw_install.js'
@@ -544,6 +545,7 @@ async function cmdInstall(opts: {
   codex?: boolean
   gemini?: boolean
   qwen?: boolean
+  kimi?: boolean
   pi?: boolean
   opencode?: boolean
   hermes?: boolean
@@ -609,6 +611,16 @@ async function cmdInstall(opts: {
       out(`Qwen Code integration already installed → ${qwenResult.settingsPath}`)
     } else {
       out(`Installed token-goat Qwen Code integration → ${qwenResult.settingsPath}`)
+    }
+  }
+
+  // --kimi is additive, exactly like --qwen above.
+  if (opts.kimi === true) {
+    const kimiResult = installKimi()
+    if (kimiResult.alreadyInstalled) {
+      out(`Kimi Code integration already installed → ${kimiResult.configPath}`)
+    } else {
+      out(`Installed token-goat Kimi Code integration → ${kimiResult.configPath}, ${kimiResult.hookScriptPath}, ${kimiResult.agentsPath}, ${kimiResult.skillPath}`)
     }
   }
 
@@ -734,6 +746,7 @@ function cmdUninstall(opts: {
   codex?: boolean
   gemini?: boolean
   qwen?: boolean
+  kimi?: boolean
   pi?: boolean
   opencode?: boolean
   hermes?: boolean
@@ -772,6 +785,7 @@ function cmdUninstall(opts: {
     { flag: opts.codex === true, run: uninstallCodex, label: 'Codex CLI integration' },
     { flag: opts.gemini === true, run: uninstallGemini, label: 'Gemini CLI integration' },
     { flag: opts.qwen === true, run: uninstallQwen, label: 'Qwen Code integration' },
+    { flag: opts.kimi === true, run: uninstallKimi, label: 'Kimi Code integration' },
     { flag: opts.pi === true, run: () => (opts.local === true ? uninstallPi({ local: true }) : uninstallPi()), label: 'pi extension' },
     { flag: opts.openclaw === true, run: uninstallOpenclaw, label: 'OpenClaw integration' },
     { flag: opts.copilot === true, run: () => (opts.local === true ? uninstallCopilotCli({ local: true }) : uninstallCopilotCli()), label: 'Copilot CLI integration' },
@@ -836,6 +850,7 @@ export function leftoverIntegrations(opts: {
   codex?: boolean
   gemini?: boolean
   qwen?: boolean
+  kimi?: boolean
   pi?: boolean
   openclaw?: boolean
   copilot?: boolean
@@ -846,6 +861,7 @@ export function leftoverIntegrations(opts: {
     { skipped: opts.codex !== true, present: isCodexInstalled, flag: '--codex', label: 'Codex CLI integration' },
     { skipped: opts.gemini !== true, present: isGeminiInstalled, flag: '--gemini', label: 'Gemini CLI integration' },
     { skipped: opts.qwen !== true, present: isQwenInstalled, flag: '--qwen', label: 'Qwen Code integration' },
+    { skipped: opts.kimi !== true, present: isKimiInstalled, flag: '--kimi', label: 'Kimi Code integration' },
     { skipped: opts.pi !== true, present: () => isPiInstalled() || isPiInstalled({ local: true }), flag: '--pi', label: 'pi extension' },
     { skipped: opts.openclaw !== true, present: isOpenclawInstalled, flag: '--openclaw', label: 'OpenClaw integration' },
     {
@@ -3397,6 +3413,7 @@ export function buildProgram(): Command {
     .option('--codex', 'also patch Codex CLI (~/.codex/config.toml, ~/.codex/AGENTS.md)')
     .option('--gemini', 'also patch Gemini CLI (~/.gemini/settings.json)')
     .option('--qwen', 'also patch Qwen Code (~/.qwen/settings.json)')
+    .option('--kimi', 'also register a Kimi Code hook config, shim, instructions block and skill ($KIMI_CODE_HOME or ~/.kimi-code: config.toml, hooks/token-goat-shim.js, AGENTS.md, skills/token-goat/SKILL.md)')
     .option('--pi', 'also drop a pi (pi-coding-agent) extension (~/.pi/agent/extensions/token-goat.ts)')
     .option('--opencode', 'also drop an opencode plugin (~/.config/opencode/plugins/token-goat.ts, %APPDATA%\\opencode\\plugins\\token-goat.ts on Windows)')
     .option('--hermes', 'verify token-goat hooks are present for Hermes Agent (writes nothing new)')
@@ -3414,6 +3431,7 @@ export function buildProgram(): Command {
     .option('--codex', 'also strip the Codex CLI integration (~/.codex/config.toml, ~/.codex/AGENTS.md)')
     .option('--gemini', 'also strip the Gemini CLI integration (~/.gemini/settings.json)')
     .option('--qwen', 'also strip the Qwen Code integration (~/.qwen/settings.json)')
+    .option('--kimi', 'also strip the Kimi Code integration (config.toml hooks, hooks/token-goat-shim.js, the AGENTS.md block and skills/token-goat under $KIMI_CODE_HOME or ~/.kimi-code)')
     .option('--pi', 'also remove the pi (pi-coding-agent) extension')
     .option('--opencode', 'also remove the opencode plugin')
     .option('--hermes', 'no-op verification flag for symmetry with install (removes no files)')

--- a/src/hooks_cli.ts
+++ b/src/hooks_cli.ts
@@ -26,7 +26,7 @@ const _LOG = {
  * Harness identifier: the Claude Code harness variant token-goat is running under.
  * Determines payload/response shape translation.
  */
-export type Harness = 'claude' | 'codex' | 'gemini' | 'grok'
+export type Harness = 'claude' | 'codex' | 'gemini' | 'grok' | 'kimi'
 
 /**
  * Hook payload: unstructured dict from harness stdin.
@@ -130,6 +130,41 @@ const GROK_TOOL_NAME_MAP: Record<string, string> = {
  */
 const GROK_INPUT_KEY_MAP: Record<string, Record<string, string>> = {
   Read: { target_file: 'file_path' },
+}
+
+/**
+ * Kimi Code tool name -> internal PascalCase tool name.
+ *
+ * Kimi's built-in tool vocabulary (`docs/en/reference/tools.md` in
+ * MoonshotAI/kimi-code) already matches token-goat's canonical names for
+ * `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Bash`, and `WebSearch`, so those
+ * need no entry here. Only the two that differ are mapped: Kimi calls its URL
+ * fetcher `FetchURL` (Claude Code's `WebFetch`) and its image/video reader
+ * `ReadMediaFile` (Claude Code reads media through `Read`). Kimi's `Agent`
+ * tool is deliberately left unmapped: it is the sub-agent spawner, not Claude
+ * Code's generic `Task`, and no handler in this codebase filters on it.
+ */
+const KIMI_TOOL_NAME_MAP: Record<string, string> = {
+  FetchURL: 'WebFetch',
+  ReadMediaFile: 'Read',
+}
+
+/**
+ * Kimi tool_input key -> internal key, per remapped tool.
+ *
+ * Kimi's v2 tools name their path argument `path`, not Claude Code's
+ * `file_path` (`ReadInputSchema` in
+ * `packages/agent-core-v2/src/agent/tools/os/read/readTool.ts` reads
+ * `args.path`; `packages/acp-server/src/events-map.ts` states "v2 tools use
+ * `path`"). getFilePath() in hooks_common.ts reads `file_path`, so Read/Write/
+ * Edit/ReadMediaFile need that rename or every path-scoped handler silently
+ * sees no path at all. Grep and Glob already send `pattern`/`path`, the keys
+ * their handlers read, and Bash already sends `command`, so none is remapped.
+ */
+const KIMI_INPUT_KEY_MAP: Record<string, Record<string, string>> = {
+  Read: { path: 'file_path' },
+  Write: { path: 'file_path' },
+  Edit: { path: 'file_path' },
 }
 
 /**
@@ -255,6 +290,24 @@ export function normalizePayload(payload: unknown, harness: Harness = 'claude'):
     const result = { ...obj }
     if (mapped) {
       result['tool_name'] = mapped
+    }
+    result['_tg_harness'] = harness
+    return result
+  }
+
+  if (harness === 'kimi') {
+    // Deliberately NOT remapToolName(): that helper only applies its input-key
+    // map when the tool NAME was also renamed, and Kimi's most important case
+    // is a tool whose name already matches (`Read`) but whose path argument
+    // does not (`path`, not `file_path`). Keying the input remap off the
+    // effective tool name instead is what makes that rename actually happen.
+    const mapped = KIMI_TOOL_NAME_MAP[toolName] ?? toolName
+    const result = { ...obj }
+    result['tool_name'] = mapped
+    const rawInput = obj['tool_input']
+    const keyMap = KIMI_INPUT_KEY_MAP[mapped]
+    if (keyMap && typeof rawInput === 'object' && rawInput !== null && !Array.isArray(rawInput)) {
+      result['tool_input'] = remapInputKeys(rawInput as Record<string, unknown>, keyMap)
     }
     result['_tg_harness'] = harness
     return result

--- a/src/relay.ts
+++ b/src/relay.ts
@@ -128,6 +128,8 @@ function harnessForNormalization(): Harness {
   if (detected === 'codex') return 'codex'
   if (detected === 'gemini') return 'gemini'
   if (detected === 'grok') return 'grok'
+  // Kimi Code's shim (src/bridges/kimi.ts) sets TOKEN_GOAT_HARNESS_OVERRIDE=kimi before dispatching, so detectHarness() resolves 'kimi' here for a real Kimi install. Its payload needs remapping because Kimi's v2 tools name their path argument `path` rather than `file_path` (and its URL fetcher is `FetchURL`, not `WebFetch`).
+  if (detected === 'kimi') return 'kimi'
   return 'claude'
 }
 

--- a/tests/bridges/registry.test.ts
+++ b/tests/bridges/registry.test.ts
@@ -196,8 +196,8 @@ describe('harness detection', () => {
         expect(detectHarness()).toBe('openclaw')
       })
 
-      it('accepts every canonical harness name, including openclaw, pi, copilot_cli, grok, qwen, and hermes', () => {
-        for (const name of ['claudecode', 'codex', 'opencode', 'gemini', 'hermes', 'openclaw', 'pi', 'copilot_cli', 'grok', 'qwen', 'generic']) {
+      it('accepts every canonical harness name, including openclaw, pi, copilot_cli, grok, qwen, kimi, and hermes', () => {
+        for (const name of ['claudecode', 'codex', 'opencode', 'gemini', 'hermes', 'openclaw', 'pi', 'copilot_cli', 'grok', 'qwen', 'kimi', 'generic']) {
           process.env['TOKEN_GOAT_HARNESS_OVERRIDE'] = name
           expect(detectHarness()).toBe(name)
         }

--- a/tests/bridges_status.test.ts
+++ b/tests/bridges_status.test.ts
@@ -45,7 +45,7 @@ describe('BRIDGE_CAPABILITY_MATRIX (static data)', () => {
   it('covers exactly the real bridge modules -- excludes hermes (no install-writer) and generic (fallback, not a harness)', () => {
     const harnesses = BRIDGE_CAPABILITY_MATRIX.map((r) => r.harness).sort()
     expect(harnesses).toEqual(
-      ['claudecode', 'codex', 'copilot_cli', 'gemini', 'grok', 'openclaw', 'opencode', 'pi', 'qwen'].sort(),
+      ['claudecode', 'codex', 'copilot_cli', 'gemini', 'grok', 'kimi', 'openclaw', 'opencode', 'pi', 'qwen'].sort(),
     )
     expect(harnesses).not.toContain('hermes')
     expect(harnesses).not.toContain('generic')
@@ -173,12 +173,12 @@ describe('formatBridgesStatus', () => {
     expect(text).toMatch(/opencode:.*tool\.execute\.before/)
   })
 
-  it('shows a 7/8 score for copilot_cli, 6/8 for claudecode, 5/8 for codex/grok/qwen, 3/8 for opencode/gemini/openclaw/pi', () => {
+  it('shows a 7/8 score for copilot_cli, 6/8 for claudecode/kimi, 5/8 for codex/grok/qwen, 3/8 for opencode/gemini/openclaw/pi', () => {
     const text = formatBridgesStatus(BRIDGE_CAPABILITY_MATRIX)
     // copilot_cli overtakes claudecode here: it wires session_start (like claudecode) *and*
     // stop via its agentStop mapping, which claudecode's settings.json wiring does not.
     expect(text).toMatch(/copilot_cli\s+.*\s7\/8/)
-    for (const harness of ['claudecode']) {
+    for (const harness of ['claudecode', 'kimi']) {
       expect(text).toMatch(new RegExp(`${harness}\\s+.*\\s6\\/8`))
     }
     for (const harness of ['codex', 'grok', 'qwen']) {

--- a/tests/hook_event_harness_matrix.test.ts
+++ b/tests/hook_event_harness_matrix.test.ts
@@ -140,6 +140,16 @@ function qwenEvents(): HookEventName[] {
   return extractKnownEvents(m[1], 'src/bridges/qwen_install.ts QWEN_EVENT_ARG')
 }
 
+/** Kimi Code's KIMI_EVENT_ARG (src/bridges/kimi_install.ts): Kimi event key -> internal event arg. */
+function kimiEvents(): HookEventName[] {
+  const src = readSrc('bridges/kimi_install.ts')
+  const m = src.match(/const KIMI_EVENT_ARG:[^\r\n]*\r?\n([\s\S]*?)\r?\n\}/)
+  if (!m || m[1] === undefined) {
+    throw new Error('KIMI_EVENT_ARG not found in src/bridges/kimi_install.ts -- update the matrix derivation')
+  }
+  return extractKnownEvents(m[1], 'src/bridges/kimi_install.ts KIMI_EVENT_ARG')
+}
+
 /** Copilot CLI's COPILOT_TO_TG_EVENT (src/bridges/copilot_cli.ts): Copilot event name -> internal event, already the value passed as the CLI event arg. */
 function copilotCliEvents(): HookEventName[] {
   const src = readSrc('bridges/copilot_cli.ts')
@@ -186,6 +196,7 @@ const DERIVED_SUPPORTED_EVENTS: Record<HarnessName, HookEventName[]> = {
   codex: codexEvents(),
   gemini: geminiEvents(),
   qwen: qwenEvents(),
+  kimi: kimiEvents(),
   pi: callHookEvents(PI_EXTENSION_SCRIPT, 'PI_EXTENSION_SCRIPT'),
   opencode: callHookEvents(OPENCODE_PLUGIN_SCRIPT, 'OPENCODE_PLUGIN_SCRIPT'),
   openclaw: callHookEvents(OPENCLAW_PLUGIN_SCRIPT, 'OPENCLAW_PLUGIN_SCRIPT'),
@@ -207,6 +218,7 @@ const EXPECTED_SUPPORTED_EVENTS: Record<HarnessName, HookEventName[]> = {
   codex: ['pre_tool_use', 'post_tool_use'],
   gemini: ['pre_tool_use', 'post_tool_use', 'pre_compact'],
   qwen: ['pre_tool_use', 'post_tool_use', 'pre_compact', 'user_prompt_submit', 'subagent_stop'],
+  kimi: ['pre_tool_use', 'post_tool_use', 'pre_compact', 'user_prompt_submit', 'subagent_stop', 'session_start'],
   pi: ['pre_tool_use', 'post_tool_use', 'pre_compact'],
   opencode: ['pre_tool_use', 'post_tool_use', 'pre_compact'],
   openclaw: ['pre_tool_use', 'post_tool_use', 'pre_compact'],

--- a/tests/install_kimi.test.ts
+++ b/tests/install_kimi.test.ts
@@ -1,0 +1,257 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import type * as NodeOs from 'node:os'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { parse, stringify } from 'smol-toml'
+
+// vi.mock is hoisted -- wrap homedir (delegating to the real implementation by
+// default) so the KIMI_CODE_HOME-unset cases below resolve `~` to an isolated
+// temp dir instead of touching a real `~/.kimi-code/` (mirrors install_qwen.test.ts).
+vi.mock('node:os', async (importOriginal) => {
+  const original = await importOriginal<typeof NodeOs>()
+  return {
+    ...original,
+    homedir: vi.fn((...args: Parameters<typeof original.homedir>) => original.homedir(...args)),
+  }
+})
+
+import * as os from 'node:os'
+
+import {
+  KimiConfigParseError,
+  KIMI_HOOK_EVENTS,
+  installKimi,
+  isKimiInstalled,
+  kimiAgentsPath,
+  kimiConfigPath,
+  kimiHome,
+  kimiHookScriptPath,
+  kimiSkillPath,
+  uninstallKimi,
+} from '../src/bridges/kimi_install.js'
+
+interface KimiHookEntry {
+  event?: string
+  matcher?: string
+  command?: string
+  timeout?: number
+}
+interface KimiConfigShape {
+  hooks?: KimiHookEntry[]
+  [key: string]: unknown
+}
+
+function readConfig(): KimiConfigShape {
+  return parse(fs.readFileSync(kimiConfigPath(), 'utf8')) as KimiConfigShape
+}
+
+/** The internal event arg each wired Kimi event maps onto, restated here rather than imported so a silent flip in the source table fails this test. */
+const KIMI_EVENT_ARG: Record<string, string> = {
+  PreToolUse: 'pre_tool_use',
+  PostToolUse: 'post_tool_use',
+  PreCompact: 'pre_compact',
+  UserPromptSubmit: 'user_prompt_submit',
+  SubagentStop: 'subagent_stop',
+  SessionStart: 'session_start',
+}
+
+let TMP: string
+let originalArgv1: string
+let originalKimiHome: string | undefined
+
+beforeEach(() => {
+  TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-kimi-install-'))
+  const homedirMock = os.homedir as unknown as ReturnType<typeof vi.fn>
+  homedirMock.mockReturnValue(TMP)
+  originalKimiHome = process.env['KIMI_CODE_HOME']
+  delete process.env['KIMI_CODE_HOME']
+  // Same rationale as install_qwen.test.ts: the installer identifies its own hook
+  // commands by a "token-goat" path segment in the baked command, which tinypool's
+  // worker entry path does not satisfy -- stub argv[1] to a realistic entry path.
+  originalArgv1 = process.argv[1]
+  process.argv[1] = path.join(TMP, 'node_modules', 'token-goat', 'dist', 'token-goat.mjs')
+})
+
+afterEach(() => {
+  process.argv[1] = originalArgv1
+  if (originalKimiHome === undefined) {
+    delete process.env['KIMI_CODE_HOME']
+  } else {
+    process.env['KIMI_CODE_HOME'] = originalKimiHome
+  }
+  fs.rmSync(TMP, { recursive: true, force: true })
+})
+
+describe('kimiHome', () => {
+  it('defaults to ~/.kimi-code, the data root Kimi Code documents', () => {
+    expect(kimiHome()).toBe(path.join(TMP, '.kimi-code'))
+  })
+
+  it('follows KIMI_CODE_HOME when set, so an isolated Kimi data root gets its own install', () => {
+    const alt = path.join(TMP, 'alt-root')
+    process.env['KIMI_CODE_HOME'] = alt
+    expect(kimiHome()).toBe(path.resolve(alt))
+    expect(kimiConfigPath()).toBe(path.join(path.resolve(alt), 'config.toml'))
+  })
+
+  it('ignores a blank KIMI_CODE_HOME rather than installing into the process working directory', () => {
+    process.env['KIMI_CODE_HOME'] = '   '
+    expect(kimiHome()).toBe(path.join(TMP, '.kimi-code'))
+  })
+})
+
+describe('installKimi', () => {
+  it('writes one [[hooks]] entry per wired event, each naming the absolute node binary, the shim and the internal event arg', () => {
+    const result = installKimi()
+    expect(result.alreadyInstalled).toBe(false)
+    expect(fs.existsSync(result.configPath)).toBe(true)
+
+    const config = readConfig()
+    const hooks = config.hooks ?? []
+    expect(hooks).toHaveLength(KIMI_HOOK_EVENTS.length)
+    expect(KIMI_HOOK_EVENTS).toEqual(['PreToolUse', 'PostToolUse', 'PreCompact', 'UserPromptSubmit', 'SubagentStop', 'SessionStart'])
+
+    for (const event of KIMI_HOOK_EVENTS) {
+      const entry = hooks.find((h) => h.event === event)
+      expect(entry, `no [[hooks]] entry for ${event}`).toBeDefined()
+      const command = entry?.command ?? ''
+      expect(command).toContain(`"${process.execPath}"`)
+      expect(command.startsWith('node ')).toBe(false)
+      expect(command).toContain(`"${kimiHookScriptPath()}"`)
+      expect(command).toContain(` ${KIMI_EVENT_ARG[event] ?? 'MISSING'}`)
+    }
+  })
+
+  it("writes only keys Kimi's strict [[hooks]] schema accepts, since an unknown key makes the whole config file fail to load", () => {
+    installKimi()
+    for (const entry of readConfig().hooks ?? []) {
+      expect(Object.keys(entry).sort()).toEqual(['command', 'event'])
+    }
+  })
+
+  it('writes the shim script, the AGENTS.md guidance block and the SKILL.md the Kimi skill loader requires', () => {
+    const result = installKimi()
+
+    const shim = fs.readFileSync(result.hookScriptPath, 'utf8')
+    expect(shim).toContain("process.env.TOKEN_GOAT_HARNESS_OVERRIDE = 'kimi'")
+    expect(shim).toContain('permissionDecision')
+
+    const agents = fs.readFileSync(result.agentsPath, 'utf8')
+    expect(agents).toContain('<!-- token-goat-kimi-begin -->')
+    expect(agents).toContain('<!-- token-goat-kimi-end -->')
+    expect(agents).toContain('## token-goat')
+
+    const skill = fs.readFileSync(result.skillPath, 'utf8')
+    expect(skill.startsWith('---\nname: token-goat\ndescription: ')).toBe(true)
+    // Kimi's SKILL.md frontmatter schema has no allowed-tools field; writing one would be
+    // invented surface. Scoped to the frontmatter block, since the shared gate body legitimately
+    // mentions the phrase in prose.
+    const frontmatter = skill.slice(0, skill.indexOf('\n---', 3) + 4)
+    expect(frontmatter).not.toContain('allowed-tools')
+    expect(frontmatter.split('\n').filter((l) => l !== '---')).toHaveLength(2)
+    expect(skill).toContain('## token-goat')
+    expect(result.skillPath).toBe(path.join(kimiHome(), 'skills', 'token-goat', 'SKILL.md'))
+  })
+
+  it('preserves unrelated config keys and foreign hook entries instead of clobbering them', () => {
+    fs.mkdirSync(kimiHome(), { recursive: true })
+    fs.writeFileSync(
+      kimiConfigPath(),
+      ['default_model = "kimi-k2"', '', '[[hooks]]', 'event = "Notification"', 'command = "notify-send hi"', ''].join('\n'),
+    )
+
+    installKimi()
+
+    const config = readConfig()
+    expect(config['default_model']).toBe('kimi-k2')
+    const foreign = (config.hooks ?? []).filter((h) => h.command === 'notify-send hi')
+    expect(foreign).toHaveLength(1)
+    expect(foreign[0]?.event).toBe('Notification')
+    expect(config.hooks ?? []).toHaveLength(KIMI_HOOK_EVENTS.length + 1)
+  })
+
+  it('is idempotent: a second install reports alreadyInstalled and adds no duplicate entry', () => {
+    installKimi()
+    const second = installKimi()
+    expect(second.alreadyInstalled).toBe(true)
+    expect(readConfig().hooks ?? []).toHaveLength(KIMI_HOOK_EVENTS.length)
+  })
+
+  it('upgrades a stale baked entry path in place rather than leaving a dead duplicate beside the current one', () => {
+    installKimi()
+    const stale = readConfig()
+    const hooks = stale.hooks ?? []
+    expect(hooks[0]).toBeDefined()
+    hooks[0] = { event: 'PreToolUse', command: '"/old/node" "/old/token-goat/dist/token-goat.mjs" pre_tool_use' }
+    fs.writeFileSync(kimiConfigPath(), stringify(stale as Record<string, unknown>))
+
+    const result = installKimi()
+
+    expect(result.alreadyInstalled).toBe(false)
+    const after = readConfig().hooks ?? []
+    expect(after).toHaveLength(KIMI_HOOK_EVENTS.length)
+    expect(after.some((h) => h.command?.includes('/old/token-goat/'))).toBe(false)
+  })
+
+  it('refuses to touch a config.toml that exists but is not parseable, so a recoverable file is never clobbered', () => {
+    fs.mkdirSync(kimiHome(), { recursive: true })
+    fs.writeFileSync(kimiConfigPath(), 'this is [not valid = toml')
+    expect(() => installKimi()).toThrow(KimiConfigParseError)
+    expect(fs.readFileSync(kimiConfigPath(), 'utf8')).toBe('this is [not valid = toml')
+  })
+})
+
+describe('isKimiInstalled', () => {
+  it('is false before install, true after, and false again once the hook entries are gone', () => {
+    expect(isKimiInstalled()).toBe(false)
+    installKimi()
+    expect(isKimiInstalled()).toBe(true)
+    uninstallKimi()
+    expect(isKimiInstalled()).toBe(false)
+  })
+
+  it('is false when only some events are wired, so a partial install is not reported as complete', () => {
+    installKimi()
+    const config = readConfig()
+    config.hooks = (config.hooks ?? []).filter((h) => h.event !== 'SessionStart')
+    fs.writeFileSync(kimiConfigPath(), stringify(config as Record<string, unknown>))
+    expect(isKimiInstalled()).toBe(false)
+  })
+})
+
+describe('uninstallKimi', () => {
+  it('removes token-goat hook entries, the shim, the skill and the AGENTS.md block, keeping foreign content', () => {
+    fs.mkdirSync(kimiHome(), { recursive: true })
+    fs.writeFileSync(kimiAgentsPath(), 'my own notes\n')
+    fs.writeFileSync(
+      kimiConfigPath(),
+      ['default_model = "kimi-k2"', '', '[[hooks]]', 'event = "Notification"', 'command = "notify-send hi"', ''].join('\n'),
+    )
+    installKimi()
+    expect(fs.existsSync(kimiSkillPath())).toBe(true)
+
+    expect(uninstallKimi()).toBe(true)
+
+    const config = readConfig()
+    expect(config['default_model']).toBe('kimi-k2')
+    expect(config.hooks ?? []).toEqual([{ event: 'Notification', command: 'notify-send hi' }])
+    expect(fs.existsSync(kimiHookScriptPath())).toBe(false)
+    expect(fs.existsSync(kimiSkillPath())).toBe(false)
+    const agents = fs.readFileSync(kimiAgentsPath(), 'utf8')
+    expect(agents).toContain('my own notes')
+    expect(agents).not.toContain('token-goat-kimi-begin')
+  })
+
+  it('drops the hooks key entirely when token-goat wrote every entry, leaving no empty array behind', () => {
+    installKimi()
+    uninstallKimi()
+    expect(readConfig().hooks).toBeUndefined()
+  })
+
+  it('returns false when there is nothing to remove', () => {
+    expect(uninstallKimi()).toBe(false)
+  })
+})

--- a/tests/uninstall_leftover_integrations.test.ts
+++ b/tests/uninstall_leftover_integrations.test.ts
@@ -85,6 +85,7 @@ describe('leftoverIntegrations', () => {
       codex: true,
       gemini: true,
       qwen: true,
+      kimi: true,
       pi: true,
       openclaw: true,
       copilot: true,

--- a/tests/wire_format_kimi.test.ts
+++ b/tests/wire_format_kimi.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Kimi Code wire-format contract (real bundle, real shim, real handlers).
+ *
+ * Kimi's stdout parser reads exactly three things (`structuredOutput()` in
+ * MoonshotAI/kimi-code `packages/agent-core-v2/src/agent/externalHooks/runner.ts`):
+ * a top-level `message`, `hookSpecificOutput.message`, and
+ * `hookSpecificOutput.permissionDecision` / `permissionDecisionReason`. It
+ * understands none of token-goat's own Claude-Code-shaped fields, so these
+ * tests drive the real KIMI_HOOK_SCRIPT against the real built bundle and
+ * assert the literal bytes Kimi would actually receive.
+ *
+ * Every payload here uses Kimi's own key spelling (`tool_input.path`, not
+ * `file_path`), which is what makes these tests also cover the kimi branch of
+ * normalizePayload: if that rename regressed, the handler would see no path,
+ * emit nothing, and the deny/hint assertions below would fail.
+ */
+
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { KIMI_HOOK_SCRIPT } from '../src/bridges/kimi.js'
+
+import { BUNDLE, ROOT } from './helpers/bundle.js'
+
+const tempDirs: string[] = []
+
+function mkIsolated(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+/**
+ * Isolated data root shared by every run in this file. The bundle resolves its
+ * config from here (dataDir() in src/constants.ts), and these fixtures re-read a
+ * file once, immediately: hints.protect_recent_reads defaults to 4, which would
+ * exempt exactly that shape from the re-read deny under test. Pinned to 0 for the
+ * same reason tests/hook_event_harness_matrix.test.ts pins it.
+ */
+let dataBase: string
+
+beforeAll(() => {
+  dataBase = mkIsolated('tg-kimi-wire-data-')
+  const configDir =
+    process.platform === 'win32' ? path.join(dataBase, 'dfk-helper', 'token-goat') : path.join(dataBase, 'token-goat')
+  fs.mkdirSync(configDir, { recursive: true })
+  fs.writeFileSync(path.join(configDir, 'config.toml'), `[hints]
+protect_recent_reads = 0
+`, 'utf8')
+}, 30000)
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // best-effort; a lingering detached worker can briefly hold a temp dir on Windows
+    }
+  }
+})
+
+/**
+ * Isolated environment for a shim run. Deliberately does NOT set
+ * TOKEN_GOAT_HARNESS_OVERRIDE: the shim is supposed to set it itself, because
+ * Kimi Code publishes no ambient per-session variable identifying its hook
+ * subprocesses. If the shim stopped doing that, the `path` -> `file_path`
+ * remap would never run and these tests would fail.
+ */
+function kimiEnv(base: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    LOCALAPPDATA: dataBase,
+    XDG_DATA_HOME: dataBase,
+    HOME: base,
+    USERPROFILE: base,
+  }
+  delete env['TOKEN_GOAT_HARNESS_OVERRIDE']
+  return env
+}
+
+interface RunResult {
+  status: number | null
+  stdout: string
+  stderr: string
+}
+
+/** Runs the real Kimi shim exactly as Kimi Code would: event arg, baked entry path, payload on stdin. */
+function runKimiShim(cwd: string, eventArg: string, payload: unknown, env: NodeJS.ProcessEnv, spawnCwd = cwd): RunResult {
+  const scriptPath = path.join(cwd, 'token-goat-shim.js')
+  fs.writeFileSync(scriptPath, KIMI_HOOK_SCRIPT, 'utf8')
+  const res = spawnSync(process.execPath, [scriptPath, eventArg, BUNDLE], {
+    cwd: spawnCwd,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    timeout: 15000,
+    env,
+  })
+  return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' }
+}
+
+describe('Kimi wire format: deny', () => {
+  it('reshapes a bundle deny into hookSpecificOutput.permissionDecision "deny" with a reason, which is the only block shape Kimi honours on exit 0', () => {
+    const cwd = mkIsolated('tg-kimi-wire-deny-')
+    const sessionId = 'kimi-wire-deny'
+    const filePath = path.join(cwd, 'large.bin')
+    // >50KB non-source file, denied outright on the second read -- the same fixture
+    // tests/hook_event_harness_matrix.test.ts uses for its deny-shape cases, run with
+    // the repository as the working directory for the same reason it does.
+    fs.writeFileSync(filePath, 'x'.repeat(60 * 1024))
+    const payload = { tool_name: 'Read', tool_input: { path: filePath }, session_id: sessionId }
+    const env = kimiEnv(cwd)
+
+    const first = runKimiShim(cwd, 'pre_tool_use', payload, env, ROOT)
+    expect(first.status, `first read, stderr: ${first.stderr}`).toBe(0)
+    const second = runKimiShim(cwd, 'pre_tool_use', payload, env, ROOT)
+    expect(second.status, `second read, stderr: ${second.stderr}`).toBe(0)
+
+    const parsed = JSON.parse(second.stdout) as {
+      message?: string
+      decision?: string
+      hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string }
+    }
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('deny')
+    expect(parsed.hookSpecificOutput?.permissionDecisionReason ?? '').toContain('was already read this session')
+    expect(parsed.message ?? '').toContain('was already read this session')
+    // Claude Code's own deny shape must not survive: Kimi ignores it outright.
+    expect(parsed.decision).toBeUndefined()
+  })
+})
+
+describe('Kimi wire format: hint', () => {
+  it('maps a bundle context hint onto the top-level `message` field Kimi reads, dropping additionalContext', () => {
+    const cwd = mkIsolated('tg-kimi-wire-hint-')
+    const sessionId = 'kimi-wire-hint'
+    const filePath = path.join(cwd, 'small.txt')
+    fs.writeFileSync(filePath, 'hello from the kimi wire-format test\n')
+    const payload = { tool_name: 'Read', tool_input: { path: filePath }, session_id: sessionId }
+    const env = kimiEnv(cwd)
+
+    const first = runKimiShim(cwd, 'pre_tool_use', payload, env)
+    expect(first.status, `first read, stderr: ${first.stderr}`).toBe(0)
+
+    const second = runKimiShim(cwd, 'pre_tool_use', payload, env)
+    expect(second.status, `second read, stderr: ${second.stderr}`).toBe(0)
+
+    const parsed = JSON.parse(second.stdout) as {
+      message?: string
+      systemMessage?: string
+      hookSpecificOutput?: { additionalContext?: string; permissionDecision?: string }
+    }
+    expect(typeof parsed.message).toBe('string')
+    expect(parsed.message ?? '').toContain('already read this session')
+    expect(parsed.hookSpecificOutput?.additionalContext).toBeUndefined()
+    expect(parsed.systemMessage).toBeUndefined()
+    // A hint must never read as a block.
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBeUndefined()
+  })
+})
+
+describe('Kimi wire format: no-op', () => {
+  it('writes nothing at all for a pass, because Kimi injects raw stdout into the model context when a structured response carries no message', () => {
+    const cwd = mkIsolated('tg-kimi-wire-noop-')
+    const filePath = path.join(cwd, 'fresh.txt')
+    fs.writeFileSync(filePath, 'first ever read\n')
+    const payload = { tool_name: 'Read', tool_input: { path: filePath }, session_id: 'kimi-wire-noop' }
+
+    const res = runKimiShim(cwd, 'pre_tool_use', payload, kimiEnv(cwd))
+
+    expect(res.status, `stderr: ${res.stderr}`).toBe(0)
+    expect(res.stdout).toBe('')
+    // The literal two-character '{}' is the specific regression this guards:
+    // on UserPromptSubmit Kimi would append it verbatim to the conversation.
+    expect(res.stdout).not.toContain('{}')
+  })
+
+  it('writes nothing and exits 0 for an unknown event name, so a stale hook entry cannot break a turn', () => {
+    const cwd = mkIsolated('tg-kimi-wire-badevent-')
+    const res = runKimiShim(cwd, 'not_a_real_event', { tool_name: 'Read' }, kimiEnv(cwd))
+    expect(res.status).toBe(0)
+    expect(res.stdout).toBe('')
+  })
+})


### PR DESCRIPTION
Adds first-class Kimi Code support: installer wiring, hook shim, agent instruction file, skill, docs and tests, matching what the other harness bridges already ship.

Closes #22

## What Kimi Code actually exposes

Every value below was read in MoonshotAI/kimi-code, not inferred:

| Surface | Value | Source |
|---|---|---|
| Data root | `~/.kimi-code`, overridable with `KIMI_CODE_HOME` | `docs/en/configuration/data-locations.md` |
| Hook config | `[[hooks]]` array of tables in `config.toml` | `docs/en/customization/hooks.md` |
| Hook fields | `event`, `matcher`, `command`, `timeout` only; the schema is `.strict()`, so any extra key makes the whole config fail to load | `packages/agent-core-v2/src/agent/externalHooks/configSection.ts` |
| Events | 20 names; only `PreToolUse`, `Stop` and `UserPromptSubmit` can block | `packages/agent-core-v2/src/agent/externalHooks/types.ts` (`HOOK_EVENT_TYPES`) |
| Payload | JSON on stdin, snake_case: `hook_event_name`, `session_id`, `cwd`, plus `tool_name` / `tool_input` on tool events | `packages/agent-core-v2/src/app/externalHooksRunner/runner.ts` (`toHookInputData`, `camelToSnake`) and `.../externalHooks/externalHooksService.ts` |
| Response | top-level `message`, `hookSpecificOutput.message`, `hookSpecificOutput.permissionDecision` / `permissionDecisionReason`; exit 0 allow, exit 2 block via stderr, any other non-zero fails open | `packages/agent-core-v2/src/agent/externalHooks/runner.ts` (`HookJsonOutputSchema`, `structuredOutput`, `resultFromExitCode`) |
| Instruction file | `$KIMI_CODE_HOME/AGENTS.md` | `docs/en/customization/agents.md` |
| Skills | `$KIMI_CODE_HOME/skills/<name>/SKILL.md`; a directory-form skill must declare `name` and `description`; there is no `allowed-tools` field | `docs/en/customization/skills.md` |
| Read tool | named `Read`, argument named `path` | `packages/agent-core-v2/src/agent/tools/os/read/readTool.ts` |

Kimi Code is not a fork of a harness token-goat already supports. Its inbound payload happens to match Claude Code's shape, but its outbound contract does not, so this bridge follows the Codex and Copilot CLI pattern of a translating shim rather than the Qwen pattern of wiring `token-goat hook <event>` in directly.

## What this adds

- `token-goat install --kimi` writes `[[hooks]]` entries for `PreToolUse`, `PostToolUse`, `PreCompact`, `UserPromptSubmit`, `SubagentStop` and `SessionStart`, each carrying only `event` and `command`.
- A shim at `~/.kimi-code/hooks/token-goat-shim.js` translates the response: a block becomes `hookSpecificOutput.permissionDecision` plus `permissionDecisionReason`, a hint becomes the top-level `message`, and a no-op writes nothing at all. Empty stdout matters: on `UserPromptSubmit` Kimi Code falls back to raw stdout when a structured response carries no message (`user-prompt.ts`), so printing `{}` would put those two characters into the model's context on every turn.
- The payload is renamed on the way in: Kimi Code's `Read` sends `tool_input.path`, and token-goat's handlers read `file_path`. `remapToolName` was deliberately not reused, because it applies its input-key map only when the tool name also changes, and here the name is already `Read`.
- `AGENTS.md` guidance block and a `SKILL.md` with only the two frontmatter fields Kimi Code's loader requires.
- `token-goat uninstall --kimi` removes all four artifacts and leaves foreign config keys and hook entries alone.

## Deliberately not implemented

- `Notification` and `Stop`: token-goat has no handler for either, so wiring them would spawn a process to do nothing.
- Input and output rewriting: `runPreToolUse` returns only a block reason and `notifyPostToolUse` is fire and forget, so Kimi Code has no channel to replace a tool's input or its result. Those responses degrade to a no-op rather than being faked.
- Ambient harness detection: Kimi Code's documented environment variables are all user-set inputs, so there is nothing for `detectHarness()` to key off. The shim sets `TOKEN_GOAT_HARNESS_OVERRIDE` itself, the same workaround the Copilot CLI and pi bridges use.

## Testing

`tests/install_kimi.test.ts` covers the installer against the real writer, and `tests/wire_format_kimi.test.ts` runs the real shim against the built bundle and asserts the literal bytes Kimi Code would receive. Every new behaviour was mutation proven: breaking the deny translation, the hint translation, the empty-stdout no-op, the `path` rename, the strict key set, the partial-install check and the uninstall each turned the matching test red on its own assertion, and green again on restore.
